### PR TITLE
Update to add Event Lists to Enrolment and support empty list of data values

### DIFF
--- a/src/main/java/org/hisp/dhis/smscompression/SMSSubmissionReader.java
+++ b/src/main/java/org/hisp/dhis/smscompression/SMSSubmissionReader.java
@@ -32,6 +32,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -177,12 +178,22 @@ public class SMSSubmissionReader
     public List<SMSAttributeValue> readAttributeValues()
         throws SMSCompressionException
     {
+        boolean isEmpty = ValueUtil.readBool( inStream );
+        if ( isEmpty )
+        {
+            return new ArrayList<>();
+        }
         return valueReader.readAttributeValues();
     }
 
     public List<SMSDataValue> readDataValues()
         throws SMSCompressionException
     {
+        boolean isEmpty = ValueUtil.readBool( inStream );
+        if ( isEmpty )
+        {
+            return new ArrayList<>();
+        }
         return valueReader.readDataValues();
     }
 

--- a/src/main/java/org/hisp/dhis/smscompression/SMSSubmissionReader.java
+++ b/src/main/java/org/hisp/dhis/smscompression/SMSSubmissionReader.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.smscompression.models.EnrollmentSMSSubmission;
 import org.hisp.dhis.smscompression.models.RelationshipSMSSubmission;
 import org.hisp.dhis.smscompression.models.SMSAttributeValue;
 import org.hisp.dhis.smscompression.models.SMSDataValue;
+import org.hisp.dhis.smscompression.models.SMSEvent;
 import org.hisp.dhis.smscompression.models.SMSMetadata;
 import org.hisp.dhis.smscompression.models.SMSSubmission;
 import org.hisp.dhis.smscompression.models.SMSSubmissionHeader;
@@ -210,5 +211,12 @@ public class SMSSubmissionReader
     {
         int eventStatusNum = inStream.read( SMSConsts.EVENT_STATUS_BITLEN );
         return SMSEventStatus.values()[eventStatusNum];
+    }
+
+    public List<SMSEvent> readEvents()
+        throws SMSCompressionException
+    {
+        // TODO: Implement me
+        return null;
     }
 }

--- a/src/main/java/org/hisp/dhis/smscompression/SMSSubmissionReader.java
+++ b/src/main/java/org/hisp/dhis/smscompression/SMSSubmissionReader.java
@@ -32,6 +32,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -216,7 +217,18 @@ public class SMSSubmissionReader
     public List<SMSEvent> readEvents()
         throws SMSCompressionException
     {
-        // TODO: Implement me
-        return null;
+        boolean hasEvents = readBool();
+        ArrayList<SMSEvent> events = new ArrayList<>();
+        if ( hasEvents )
+        {
+            for ( boolean hasNext = true; hasNext; hasNext = readBool() )
+            {
+                SMSEvent event = new SMSEvent();
+                event.readEvent( this );
+                events.add( event );
+            }
+        }
+
+        return events;
     }
 }

--- a/src/main/java/org/hisp/dhis/smscompression/SMSSubmissionReader.java
+++ b/src/main/java/org/hisp/dhis/smscompression/SMSSubmissionReader.java
@@ -179,22 +179,12 @@ public class SMSSubmissionReader
     public List<SMSAttributeValue> readAttributeValues()
         throws SMSCompressionException
     {
-        boolean isEmpty = ValueUtil.readBool( inStream );
-        if ( isEmpty )
-        {
-            return new ArrayList<>();
-        }
         return valueReader.readAttributeValues();
     }
 
     public List<SMSDataValue> readDataValues()
         throws SMSCompressionException
     {
-        boolean isEmpty = ValueUtil.readBool( inStream );
-        if ( isEmpty )
-        {
-            return new ArrayList<>();
-        }
         return valueReader.readDataValues();
     }
 

--- a/src/main/java/org/hisp/dhis/smscompression/SMSSubmissionWriter.java
+++ b/src/main/java/org/hisp/dhis/smscompression/SMSSubmissionWriter.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
 
 import org.hisp.dhis.smscompression.SMSConsts.SMSEventStatus;
@@ -199,6 +200,16 @@ public class SMSSubmissionWriter
     public void writeEvents( List<SMSEvent> events )
         throws SMSCompressionException
     {
-        // TODO: Implement me
+        boolean hasEvents = (events != null && !events.isEmpty());
+        writeBool( hasEvents );
+        if ( hasEvents )
+        {
+            for ( Iterator<SMSEvent> eventIter = events.iterator(); eventIter.hasNext(); )
+            {
+                SMSEvent event = eventIter.next();
+                event.writeEvent( this );
+                writeBool( eventIter.hasNext() );
+            }
+        }
     }
 }

--- a/src/main/java/org/hisp/dhis/smscompression/SMSSubmissionWriter.java
+++ b/src/main/java/org/hisp/dhis/smscompression/SMSSubmissionWriter.java
@@ -160,13 +160,23 @@ public class SMSSubmissionWriter
     public void writeAttributeValues( List<SMSAttributeValue> values )
         throws SMSCompressionException
     {
-        valueWriter.writeAttributeValues( values );
+        boolean isEmpty = (values == null || values.isEmpty());
+        ValueUtil.writeBool( isEmpty, outStream );
+        if ( !isEmpty )
+        {
+            valueWriter.writeAttributeValues( values );
+        }
     }
 
     public void writeDataValues( List<SMSDataValue> values )
         throws SMSCompressionException
     {
-        valueWriter.writeDataValues( values );
+        boolean isEmpty = (values == null || values.isEmpty());
+        ValueUtil.writeBool( isEmpty, outStream );
+        if ( !isEmpty )
+        {
+            valueWriter.writeDataValues( values );
+        }
     }
 
     public void writeBool( boolean val )

--- a/src/main/java/org/hisp/dhis/smscompression/SMSSubmissionWriter.java
+++ b/src/main/java/org/hisp/dhis/smscompression/SMSSubmissionWriter.java
@@ -82,11 +82,17 @@ public class SMSSubmissionWriter
     public byte[] compress( SMSSubmission subm )
         throws SMSCompressionException
     {
+        return compress( subm, subm.getCurrentVersion() );
+    }
+
+    public byte[] compress( SMSSubmission subm, int version )
+        throws SMSCompressionException
+    {
         this.byteStream = new ByteArrayOutputStream();
         this.outStream = new BitOutputStream( byteStream );
         this.valueWriter = new ValueWriter( outStream, meta, hashingEnabled );
 
-        subm.write( meta, this );
+        subm.write( meta, this, version );
 
         return toByteArray();
     }
@@ -162,23 +168,13 @@ public class SMSSubmissionWriter
     public void writeAttributeValues( List<SMSAttributeValue> values )
         throws SMSCompressionException
     {
-        boolean isEmpty = (values == null || values.isEmpty());
-        ValueUtil.writeBool( isEmpty, outStream );
-        if ( !isEmpty )
-        {
-            valueWriter.writeAttributeValues( values );
-        }
+        valueWriter.writeAttributeValues( values );
     }
 
     public void writeDataValues( List<SMSDataValue> values )
         throws SMSCompressionException
     {
-        boolean isEmpty = (values == null || values.isEmpty());
-        ValueUtil.writeBool( isEmpty, outStream );
-        if ( !isEmpty )
-        {
-            valueWriter.writeDataValues( values );
-        }
+        valueWriter.writeDataValues( values );
     }
 
     public void writeBool( boolean val )

--- a/src/main/java/org/hisp/dhis/smscompression/SMSSubmissionWriter.java
+++ b/src/main/java/org/hisp/dhis/smscompression/SMSSubmissionWriter.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.smscompression.SMSConsts.SMSEventStatus;
 import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
 import org.hisp.dhis.smscompression.models.SMSAttributeValue;
 import org.hisp.dhis.smscompression.models.SMSDataValue;
+import org.hisp.dhis.smscompression.models.SMSEvent;
 import org.hisp.dhis.smscompression.models.SMSMetadata;
 import org.hisp.dhis.smscompression.models.SMSSubmission;
 import org.hisp.dhis.smscompression.models.UID;
@@ -193,5 +194,11 @@ public class SMSSubmissionWriter
         throws SMSCompressionException
     {
         outStream.write( eventStatus.ordinal(), SMSConsts.EVENT_STATUS_BITLEN );
+    }
+
+    public void writeEvents( List<SMSEvent> events )
+        throws SMSCompressionException
+    {
+        // TODO: Implement me
     }
 }

--- a/src/main/java/org/hisp/dhis/smscompression/models/AggregateDatasetSMSSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/AggregateDatasetSMSSubmission.java
@@ -147,6 +147,8 @@ public class AggregateDatasetSMSSubmission
         case 2:
             writeSubmV2( writer );
             break;
+        default:
+            throw new SMSCompressionException( versionError( version ) );
         }
     }
 
@@ -189,6 +191,8 @@ public class AggregateDatasetSMSSubmission
         case 2:
             readSubmV2( reader );
             break;
+        default:
+            throw new SMSCompressionException( versionError( version ) );
         }
     }
 

--- a/src/main/java/org/hisp/dhis/smscompression/models/DeleteSMSSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/DeleteSMSSubmission.java
@@ -70,7 +70,7 @@ public class DeleteSMSSubmission
     public void writeSubm( SMSSubmissionWriter writer, int version )
         throws SMSCompressionException
     {
-        if ( version != 1 )
+        if ( version != 1 && version != 2 )
         {
             throw new SMSCompressionException( versionError( version ) );
         }
@@ -81,7 +81,7 @@ public class DeleteSMSSubmission
     public void readSubm( SMSSubmissionReader reader, int version )
         throws SMSCompressionException
     {
-        if ( version != 1 )
+        if ( version != 1 && version != 2 )
         {
             throw new SMSCompressionException( versionError( version ) );
         }
@@ -91,7 +91,7 @@ public class DeleteSMSSubmission
     @Override
     public int getCurrentVersion()
     {
-        return 1;
+        return 2;
     }
 
     @Override

--- a/src/main/java/org/hisp/dhis/smscompression/models/DeleteSMSSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/DeleteSMSSubmission.java
@@ -70,6 +70,10 @@ public class DeleteSMSSubmission
     public void writeSubm( SMSSubmissionWriter writer, int version )
         throws SMSCompressionException
     {
+        if ( version != 1 )
+        {
+            throw new SMSCompressionException( versionError( version ) );
+        }
         writer.writeID( event );
     }
 
@@ -77,6 +81,10 @@ public class DeleteSMSSubmission
     public void readSubm( SMSSubmissionReader reader, int version )
         throws SMSCompressionException
     {
+        if ( version != 1 )
+        {
+            throw new SMSCompressionException( versionError( version ) );
+        }
         this.event = reader.readID( MetadataType.EVENT );
     }
 

--- a/src/main/java/org/hisp/dhis/smscompression/models/DeleteSMSSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/DeleteSMSSubmission.java
@@ -67,7 +67,7 @@ public class DeleteSMSSubmission
     /* Implementation of abstract methods */
 
     @Override
-    public void writeSubm( SMSSubmissionWriter writer )
+    public void writeSubm( SMSSubmissionWriter writer, int version )
         throws SMSCompressionException
     {
         writer.writeID( event );

--- a/src/main/java/org/hisp/dhis/smscompression/models/EnrollmentSMSSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/EnrollmentSMSSubmission.java
@@ -180,7 +180,6 @@ public class EnrollmentSMSSubmission
         writer.writeID( enrollment );
         writer.writeDate( timestamp );
         writer.writeAttributeValues( values );
-        writer.writeEvents( events );
     }
 
     private void writeSubmV2( SMSSubmissionWriter writer )
@@ -233,7 +232,7 @@ public class EnrollmentSMSSubmission
         this.enrollment = reader.readID( MetadataType.ENROLLMENT );
         this.timestamp = reader.readDate();
         this.values = reader.readAttributeValues();
-        this.events = reader.readEvents();
+        this.events = new ArrayList<SMSEvent>();
     }
 
     public void readSubmV2( SMSSubmissionReader reader )

--- a/src/main/java/org/hisp/dhis/smscompression/models/EnrollmentSMSSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/EnrollmentSMSSubmission.java
@@ -184,7 +184,7 @@ public class EnrollmentSMSSubmission
     @Override
     public int getCurrentVersion()
     {
-        return 1;
+        return 2;
     }
 
     @Override

--- a/src/main/java/org/hisp/dhis/smscompression/models/EnrollmentSMSSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/EnrollmentSMSSubmission.java
@@ -167,6 +167,8 @@ public class EnrollmentSMSSubmission
         case 2:
             writeSubmV2( writer );
             break;
+        default:
+            throw new SMSCompressionException( versionError( version ) );
         }
     }
 
@@ -219,6 +221,8 @@ public class EnrollmentSMSSubmission
         case 2:
             readSubmV2( reader );
             break;
+        default:
+            throw new SMSCompressionException( versionError( version ) );
         }
     }
 

--- a/src/main/java/org/hisp/dhis/smscompression/models/EnrollmentSMSSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/EnrollmentSMSSubmission.java
@@ -56,6 +56,8 @@ public class EnrollmentSMSSubmission
 
     protected List<SMSAttributeValue> values;
 
+    protected List<SMSEvent> events;
+
     public UID getOrgUnit()
     {
         return orgUnit;
@@ -126,6 +128,16 @@ public class EnrollmentSMSSubmission
         this.values = values;
     }
 
+    public List<SMSEvent> getEvents()
+    {
+        return events;
+    }
+
+    public void setEvents( List<SMSEvent> events )
+    {
+        this.events = events;
+    }
+
     @Override
     public boolean equals( Object o )
     {
@@ -138,7 +150,7 @@ public class EnrollmentSMSSubmission
         return orgUnit.equals( subm.orgUnit ) && trackerProgram.equals( subm.trackerProgram )
             && trackedEntityType.equals( subm.trackedEntityType )
             && trackedEntityInstance.equals( subm.trackedEntityInstance ) && enrollment.equals( subm.enrollment )
-            && timestamp.equals( subm.timestamp ) && values.equals( subm.values );
+            && timestamp.equals( subm.timestamp ) && values.equals( subm.values ) && events.equals( subm.events );
     }
 
     @Override
@@ -152,6 +164,7 @@ public class EnrollmentSMSSubmission
         writer.writeID( enrollment );
         writer.writeDate( timestamp );
         writer.writeAttributeValues( values );
+        writer.writeEvents( events );
     }
 
     @Override
@@ -165,6 +178,7 @@ public class EnrollmentSMSSubmission
         this.enrollment = reader.readID( MetadataType.ENROLLMENT );
         this.timestamp = reader.readDate();
         this.values = reader.readAttributeValues();
+        this.events = reader.readEvents();
     }
 
     @Override

--- a/src/main/java/org/hisp/dhis/smscompression/models/RelationshipSMSSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/RelationshipSMSSubmission.java
@@ -105,7 +105,7 @@ public class RelationshipSMSSubmission
     /* Implementation of abstract methods */
 
     @Override
-    public void writeSubm( SMSSubmissionWriter writer )
+    public void writeSubm( SMSSubmissionWriter writer, int version )
         throws SMSCompressionException
     {
         writer.writeID( relationshipType );

--- a/src/main/java/org/hisp/dhis/smscompression/models/RelationshipSMSSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/RelationshipSMSSubmission.java
@@ -108,6 +108,10 @@ public class RelationshipSMSSubmission
     public void writeSubm( SMSSubmissionWriter writer, int version )
         throws SMSCompressionException
     {
+        if ( version != 1 )
+        {
+            throw new SMSCompressionException( versionError( version ) );
+        }
         writer.writeID( relationshipType );
         writer.writeID( relationship );
         writer.writeNewID( from.uid );
@@ -118,6 +122,10 @@ public class RelationshipSMSSubmission
     public void readSubm( SMSSubmissionReader reader, int version )
         throws SMSCompressionException
     {
+        if ( version != 1 )
+        {
+            throw new SMSCompressionException( versionError( version ) );
+        }
         this.relationshipType = reader.readID( MetadataType.RELATIONSHIP_TYPE );
         this.relationship = reader.readID( MetadataType.RELATIONSHIP );
         this.from = new UID( reader.readNewID(), null );

--- a/src/main/java/org/hisp/dhis/smscompression/models/RelationshipSMSSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/RelationshipSMSSubmission.java
@@ -108,7 +108,7 @@ public class RelationshipSMSSubmission
     public void writeSubm( SMSSubmissionWriter writer, int version )
         throws SMSCompressionException
     {
-        if ( version != 1 )
+        if ( version != 1 && version != 2 )
         {
             throw new SMSCompressionException( versionError( version ) );
         }
@@ -122,7 +122,7 @@ public class RelationshipSMSSubmission
     public void readSubm( SMSSubmissionReader reader, int version )
         throws SMSCompressionException
     {
-        if ( version != 1 )
+        if ( version != 1 && version != 2 )
         {
             throw new SMSCompressionException( versionError( version ) );
         }
@@ -135,7 +135,7 @@ public class RelationshipSMSSubmission
     @Override
     public int getCurrentVersion()
     {
-        return 1;
+        return 2;
     }
 
     @Override

--- a/src/main/java/org/hisp/dhis/smscompression/models/SMSEvent.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/SMSEvent.java
@@ -114,7 +114,11 @@ public class SMSEvent
     @Override
     public boolean equals( Object o )
     {
-        if ( !super.equals( o ) )
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
         {
             return false;
         }
@@ -136,7 +140,7 @@ public class SMSEvent
         writer.writeDataValues( values );
     }
 
-    public void readEvent( SMSSubmissionReader reader, int version )
+    public void readEvent( SMSSubmissionReader reader )
         throws SMSCompressionException
     {
         this.programStage = reader.readID( MetadataType.PROGRAM_STAGE );

--- a/src/main/java/org/hisp/dhis/smscompression/models/SMSEvent.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/SMSEvent.java
@@ -56,9 +56,9 @@ public class SMSEvent
         return programStage;
     }
 
-    public void setProgramStage( UID programStage )
+    public void setProgramStage( String programStage )
     {
-        this.programStage = programStage;
+        this.programStage = new UID( programStage, MetadataType.PROGRAM_STAGE );
     }
 
     public SMSEventStatus getEventStatus()
@@ -76,9 +76,9 @@ public class SMSEvent
         return attributeOptionCombo;
     }
 
-    public void setAttributeOptionCombo( UID attributeOptionCombo )
+    public void setAttributeOptionCombo( String attributeOptionCombo )
     {
-        this.attributeOptionCombo = attributeOptionCombo;
+        this.attributeOptionCombo = new UID( attributeOptionCombo, MetadataType.CATEGORY_OPTION_COMBO );
     }
 
     public UID getEvent()
@@ -86,9 +86,9 @@ public class SMSEvent
         return event;
     }
 
-    public void setEvent( UID event )
+    public void setEvent( String event )
     {
-        this.event = event;
+        this.event = new UID( event, MetadataType.EVENT );
     }
 
     public Date getTimestamp()
@@ -122,11 +122,11 @@ public class SMSEvent
         {
             return false;
         }
-        SMSEvent event = (SMSEvent) o;
+        SMSEvent e = (SMSEvent) o;
 
-        return programStage.equals( event.programStage ) && eventStatus == event.eventStatus
-            && attributeOptionCombo.equals( event.attributeOptionCombo ) && event.equals( event.event )
-            && timestamp.equals( event.timestamp ) && values.equals( event.values );
+        return programStage.equals( e.programStage ) && eventStatus == e.eventStatus
+            && attributeOptionCombo.equals( e.attributeOptionCombo ) && event.equals( e.event )
+            && timestamp.equals( e.timestamp ) && values.equals( e.values );
     }
 
     public void writeEvent( SMSSubmissionWriter writer )

--- a/src/main/java/org/hisp/dhis/smscompression/models/SMSEvent.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/SMSEvent.java
@@ -1,0 +1,149 @@
+package org.hisp.dhis.smscompression.models;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.Date;
+import java.util.List;
+
+import org.hisp.dhis.smscompression.SMSCompressionException;
+import org.hisp.dhis.smscompression.SMSConsts.MetadataType;
+import org.hisp.dhis.smscompression.SMSConsts.SMSEventStatus;
+import org.hisp.dhis.smscompression.SMSSubmissionReader;
+import org.hisp.dhis.smscompression.SMSSubmissionWriter;
+
+public class SMSEvent
+{
+    protected UID programStage;
+
+    protected SMSEventStatus eventStatus;
+
+    protected UID attributeOptionCombo;
+
+    protected UID event;
+
+    protected Date timestamp;
+
+    protected List<SMSDataValue> values;
+
+    public UID getProgramStage()
+    {
+        return programStage;
+    }
+
+    public void setProgramStage( UID programStage )
+    {
+        this.programStage = programStage;
+    }
+
+    public SMSEventStatus getEventStatus()
+    {
+        return eventStatus;
+    }
+
+    public void setEventStatus( SMSEventStatus eventStatus )
+    {
+        this.eventStatus = eventStatus;
+    }
+
+    public UID getAttributeOptionCombo()
+    {
+        return attributeOptionCombo;
+    }
+
+    public void setAttributeOptionCombo( UID attributeOptionCombo )
+    {
+        this.attributeOptionCombo = attributeOptionCombo;
+    }
+
+    public UID getEvent()
+    {
+        return event;
+    }
+
+    public void setEvent( UID event )
+    {
+        this.event = event;
+    }
+
+    public Date getTimestamp()
+    {
+        return timestamp;
+    }
+
+    public void setTimestamp( Date timestamp )
+    {
+        this.timestamp = timestamp;
+    }
+
+    public List<SMSDataValue> getValues()
+    {
+        return values;
+    }
+
+    public void setValues( List<SMSDataValue> values )
+    {
+        this.values = values;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( !super.equals( o ) )
+        {
+            return false;
+        }
+        SMSEvent event = (SMSEvent) o;
+
+        return programStage.equals( event.programStage ) && eventStatus == event.eventStatus
+            && attributeOptionCombo.equals( event.attributeOptionCombo ) && event.equals( event.event )
+            && timestamp.equals( event.timestamp ) && values.equals( event.values );
+    }
+
+    public void writeEvent( SMSSubmissionWriter writer )
+        throws SMSCompressionException
+    {
+        writer.writeID( programStage );
+        writer.writeEventStatus( eventStatus );
+        writer.writeID( attributeOptionCombo );
+        writer.writeID( event );
+        writer.writeDate( timestamp );
+        writer.writeDataValues( values );
+    }
+
+    public void readEvent( SMSSubmissionReader reader, int version )
+        throws SMSCompressionException
+    {
+        this.programStage = reader.readID( MetadataType.PROGRAM_STAGE );
+        this.eventStatus = reader.readEventStatus();
+        this.attributeOptionCombo = reader.readID( MetadataType.CATEGORY_OPTION_COMBO );
+        this.event = reader.readID( MetadataType.EVENT );
+        this.timestamp = reader.readDate();
+        this.values = reader.readDataValues();
+    }
+}

--- a/src/main/java/org/hisp/dhis/smscompression/models/SMSSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/SMSSubmission.java
@@ -46,7 +46,9 @@ public abstract class SMSSubmission
 
     public abstract SubmissionType getType();
 
-    public abstract void writeSubm( SMSSubmissionWriter writer )
+    // Note: When handling versioning, create a new method to handle
+    // each version, rather than handling all formats in this method alone
+    public abstract void writeSubm( SMSSubmissionWriter writer, int version )
         throws SMSCompressionException;
 
     public abstract void readSubm( SMSSubmissionReader reader, int version )
@@ -56,7 +58,6 @@ public abstract class SMSSubmission
     {
         this.header = new SMSSubmissionHeader();
         header.setType( this.getType() );
-        header.setVersion( this.getCurrentVersion() );
         // Initialise the submission ID so we know if it's been set correctly
         header.setSubmissionID( -1 );
     }
@@ -102,7 +103,7 @@ public abstract class SMSSubmission
         // TODO: We should run validations on each submission here
     }
 
-    public void write( SMSMetadata meta, SMSSubmissionWriter writer )
+    public void write( SMSMetadata meta, SMSSubmissionWriter writer, int version )
         throws SMSCompressionException
     {
         // Ensure we set the lastSyncDate in the subm header
@@ -110,9 +111,10 @@ public abstract class SMSSubmission
         header.setLastSyncDate( lastSyncDate );
 
         validateSubmission();
+        header.setVersion( version );
         header.writeHeader( writer );
         writer.writeID( userID );
-        writeSubm( writer );
+        writeSubm( writer, version );
     }
 
     public void read( SMSSubmissionReader reader, SMSSubmissionHeader header )

--- a/src/main/java/org/hisp/dhis/smscompression/models/SMSSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/SMSSubmission.java
@@ -124,4 +124,9 @@ public abstract class SMSSubmission
         this.userID = reader.readID( MetadataType.USER );
         readSubm( reader, this.header.getVersion() );
     }
+
+    protected String versionError( int version )
+    {
+        return String.format( "Version %d of %s is not supported", version, this.getClass().getSimpleName() );
+    }
 }

--- a/src/main/java/org/hisp/dhis/smscompression/models/SimpleEventSMSSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/SimpleEventSMSSubmission.java
@@ -159,6 +159,8 @@ public class SimpleEventSMSSubmission
         case 2:
             writeSubmV2( writer );
             break;
+        default:
+            throw new SMSCompressionException( versionError( version ) );
         }
     }
 
@@ -203,6 +205,8 @@ public class SimpleEventSMSSubmission
         case 2:
             readSubmV2( reader );
             break;
+        default:
+            throw new SMSCompressionException( versionError( version ) );
         }
     }
 

--- a/src/main/java/org/hisp/dhis/smscompression/models/TrackerEventSMSSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/TrackerEventSMSSubmission.java
@@ -172,6 +172,8 @@ public class TrackerEventSMSSubmission
         case 2:
             writeSubmV2( writer );
             break;
+        default:
+            throw new SMSCompressionException( versionError( version ) );
         }
     }
 
@@ -218,6 +220,8 @@ public class TrackerEventSMSSubmission
         case 2:
             readSubmV2( reader );
             break;
+        default:
+            throw new SMSCompressionException( versionError( version ) );
         }
     }
 

--- a/src/main/java/org/hisp/dhis/smscompression/models/TrackerEventSMSSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/TrackerEventSMSSubmission.java
@@ -1,5 +1,7 @@
 package org.hisp.dhis.smscompression.models;
 
+import java.util.ArrayList;
+
 /*
  * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
@@ -33,8 +35,8 @@ import java.util.List;
 
 import org.hisp.dhis.smscompression.SMSCompressionException;
 import org.hisp.dhis.smscompression.SMSConsts;
-import org.hisp.dhis.smscompression.SMSConsts.SMSEventStatus;
 import org.hisp.dhis.smscompression.SMSConsts.MetadataType;
+import org.hisp.dhis.smscompression.SMSConsts.SMSEventStatus;
 import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
 import org.hisp.dhis.smscompression.SMSSubmissionReader;
 import org.hisp.dhis.smscompression.SMSSubmissionWriter;
@@ -159,7 +161,21 @@ public class TrackerEventSMSSubmission
     /* Implementation of abstract methods */
 
     @Override
-    public void writeSubm( SMSSubmissionWriter writer )
+    public void writeSubm( SMSSubmissionWriter writer, int version )
+        throws SMSCompressionException
+    {
+        switch ( version )
+        {
+        case 1:
+            writeSubmV1( writer );
+            break;
+        case 2:
+            writeSubmV2( writer );
+            break;
+        }
+    }
+
+    private void writeSubmV1( SMSSubmissionWriter writer )
         throws SMSCompressionException
     {
         writer.writeID( orgUnit );
@@ -172,8 +188,40 @@ public class TrackerEventSMSSubmission
         writer.writeDataValues( values );
     }
 
+    private void writeSubmV2( SMSSubmissionWriter writer )
+        throws SMSCompressionException
+    {
+        writer.writeID( orgUnit );
+        writer.writeID( programStage );
+        writer.writeEventStatus( eventStatus );
+        writer.writeID( attributeOptionCombo );
+        writer.writeID( enrollment );
+        writer.writeID( event );
+        writer.writeDate( timestamp );
+        boolean hasValues = (values != null && !values.isEmpty());
+        writer.writeBool( hasValues );
+        if ( hasValues )
+        {
+            writer.writeDataValues( values );
+        }
+    }
+
     @Override
     public void readSubm( SMSSubmissionReader reader, int version )
+        throws SMSCompressionException
+    {
+        switch ( version )
+        {
+        case 1:
+            readSubmV1( reader );
+            break;
+        case 2:
+            readSubmV2( reader );
+            break;
+        }
+    }
+
+    private void readSubmV1( SMSSubmissionReader reader )
         throws SMSCompressionException
     {
         this.orgUnit = reader.readID( MetadataType.ORGANISATION_UNIT );
@@ -186,10 +234,24 @@ public class TrackerEventSMSSubmission
         this.values = reader.readDataValues();
     }
 
+    private void readSubmV2( SMSSubmissionReader reader )
+        throws SMSCompressionException
+    {
+        this.orgUnit = reader.readID( MetadataType.ORGANISATION_UNIT );
+        this.programStage = reader.readID( MetadataType.PROGRAM_STAGE );
+        this.eventStatus = reader.readEventStatus();
+        this.attributeOptionCombo = reader.readID( MetadataType.CATEGORY_OPTION_COMBO );
+        this.enrollment = reader.readID( MetadataType.ENROLLMENT );
+        this.event = reader.readID( MetadataType.EVENT );
+        this.timestamp = reader.readDate();
+        boolean hasValues = reader.readBool();
+        this.values = hasValues ? reader.readDataValues() : new ArrayList<SMSDataValue>();
+    }
+
     @Override
     public int getCurrentVersion()
     {
-        return 1;
+        return 2;
     }
 
     @Override

--- a/src/test/java/org/hisp/dhis/smscompression/TestEmptyVals.java
+++ b/src/test/java/org/hisp/dhis/smscompression/TestEmptyVals.java
@@ -1,0 +1,163 @@
+package org.hisp.dhis.smscompression;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.io.FileReader;
+
+import org.apache.commons.io.IOUtils;
+import org.hisp.dhis.smscompression.models.AggregateDatasetSMSSubmission;
+import org.hisp.dhis.smscompression.models.EnrollmentSMSSubmission;
+import org.hisp.dhis.smscompression.models.SMSMetadata;
+import org.hisp.dhis.smscompression.models.SMSSubmission;
+import org.hisp.dhis.smscompression.models.SMSSubmissionHeader;
+import org.hisp.dhis.smscompression.models.SimpleEventSMSSubmission;
+import org.hisp.dhis.smscompression.models.TrackerEventSMSSubmission;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.gson.Gson;
+
+public class TestEmptyVals
+{
+    SMSMetadata meta;
+
+    SMSSubmissionWriter writer;
+
+    SMSSubmissionReader reader;
+
+    public String compressSubm( SMSSubmission subm )
+        throws Exception
+    {
+        byte[] compressSubm = writer.compress( subm );
+        String comp64 = TestUtils.encBase64( compressSubm );
+        TestUtils.printBase64Subm( comp64, subm.getClass() );
+        return comp64;
+    }
+
+    public SMSSubmission decompressSubm( String comp64 )
+        throws Exception
+    {
+        byte[] decSubmBytes = TestUtils.decBase64( comp64 );
+        SMSSubmissionHeader header = reader.readHeader( decSubmBytes );
+        Assert.assertNotNull( header );
+        return reader.readSubmission( decSubmBytes, meta );
+    }
+
+    @Before
+    public void init()
+        throws Exception
+    {
+        Gson gson = new Gson();
+        String metadataJson = IOUtils.toString( new FileReader( "src/test/resources/metadata.json" ) );
+        meta = gson.fromJson( metadataJson, SMSMetadata.class );
+        writer = new SMSSubmissionWriter( meta );
+        reader = new SMSSubmissionReader();
+    }
+
+    @After
+    public void cleanup()
+    {
+
+    }
+
+    @Test
+    public void testEncDecSimpleEventEmptyVals()
+    {
+        try
+        {
+            SimpleEventSMSSubmission origSubm = TestUtils.createSimpleEventSubmissionEmptyVals();
+            String comp64 = compressSubm( origSubm );
+            SimpleEventSMSSubmission decSubm = (SimpleEventSMSSubmission) decompressSubm( comp64 );
+
+            TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+            Assert.fail( e.getMessage() );
+        }
+    }
+
+    @Test
+    public void testEncDecAggregateDatasetEmptyVals()
+    {
+        try
+        {
+            AggregateDatasetSMSSubmission origSubm = TestUtils.createAggregateDatasetSubmissionEmptyVals();
+            String comp64 = compressSubm( origSubm );
+            AggregateDatasetSMSSubmission decSubm = (AggregateDatasetSMSSubmission) decompressSubm( comp64 );
+
+            TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+            Assert.fail( e.getMessage() );
+        }
+    }
+
+    @Test
+    public void testEncDecEnrollmentEmptyVals()
+    {
+        try
+        {
+            EnrollmentSMSSubmission origSubm = TestUtils.createEnrollmentSubmissionEmptyVals();
+            String comp64 = compressSubm( origSubm );
+            EnrollmentSMSSubmission decSubm = (EnrollmentSMSSubmission) decompressSubm( comp64 );
+
+            TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+            Assert.fail( e.getMessage() );
+        }
+    }
+
+    @Test
+    public void testEncDecTrackerEventEmptyVals()
+    {
+        try
+        {
+            TrackerEventSMSSubmission origSubm = TestUtils.createTrackerEventSubmissionEmptyVals();
+            String comp64 = compressSubm( origSubm );
+            TrackerEventSMSSubmission decSubm = (TrackerEventSMSSubmission) decompressSubm( comp64 );
+
+            TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+            Assert.fail( e.getMessage() );
+        }
+    }
+
+}

--- a/src/test/java/org/hisp/dhis/smscompression/TestEncodeDecode.java
+++ b/src/test/java/org/hisp/dhis/smscompression/TestEncodeDecode.java
@@ -1,5 +1,7 @@
 package org.hisp.dhis.smscompression;
 
+import static org.junit.Assert.assertEquals;
+
 /*
  * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
@@ -216,4 +218,43 @@ public class TestEncodeDecode
         }
     }
 
+    @Test
+    public void testInvalidCRCEnd()
+    {
+        try
+        {
+            TrackerEventSMSSubmission origSubm = TestUtils.createTrackerEventSubmission();
+            String comp64 = compressSubm( origSubm );
+            comp64 = comp64.subSequence( 0, comp64.length() - 1 ).toString();
+            decompressSubm( comp64 );
+        }
+        catch ( Exception e )
+        {
+            assertEquals( e.getClass(), SMSCompressionException.class );
+            assertEquals( e.getMessage(), "Invalid CRC - CRC in header does not match submission" );
+            return;
+        }
+
+        Assert.fail( "Expected Invalid CRC exception not found" );
+    }
+
+    @Test
+    public void testInvalidCRCBegin()
+    {
+        try
+        {
+            TrackerEventSMSSubmission origSubm = TestUtils.createTrackerEventSubmission();
+            String comp64 = compressSubm( origSubm );
+            comp64 = comp64.subSequence( 1, comp64.length() ).toString();
+            decompressSubm( comp64 );
+        }
+        catch ( Exception e )
+        {
+            assertEquals( e.getClass(), SMSCompressionException.class );
+            assertEquals( e.getMessage(), "Invalid CRC - CRC in header does not match submission" );
+            return;
+        }
+
+        Assert.fail( "Expected Invalid CRC exception not found" );
+    }
 }

--- a/src/test/java/org/hisp/dhis/smscompression/TestEncodeDecode.java
+++ b/src/test/java/org/hisp/dhis/smscompression/TestEncodeDecode.java
@@ -181,6 +181,24 @@ public class TestEncodeDecode
     }
 
     @Test
+    public void testEncodeEnrollmentNoEvents()
+    {
+        try
+        {
+            EnrollmentSMSSubmission origSubm = TestUtils.createEnrollmentSubmissionNoEvents();
+            String comp64 = compressSubm( origSubm );
+            EnrollmentSMSSubmission decSubm = (EnrollmentSMSSubmission) decompressSubm( comp64 );
+
+            TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+            Assert.fail( e.getMessage() );
+        }
+    }
+
+    @Test
     public void testEncodeTrackerEvent()
     {
         try

--- a/src/test/java/org/hisp/dhis/smscompression/TestUtils.java
+++ b/src/test/java/org/hisp/dhis/smscompression/TestUtils.java
@@ -240,6 +240,7 @@ public class TestUtils
         }
 
         return events;
+    }
 
     // Submissions with empty values
     public static SimpleEventSMSSubmission createSimpleEventSubmissionEmptyVals()
@@ -288,8 +289,11 @@ public class TestUtils
         subm.setTrackedEntityInstance( "T2bRuLEGoVN" ); // Newly generated UID
         subm.setEnrollment( "p7M1gUFK37W" ); // Newly generated UID
         subm.setTimestamp( getNowWithoutMillis() );
-        ArrayList<SMSAttributeValue> values = new ArrayList<>();
+        List<SMSAttributeValue> values = new ArrayList<>();
         subm.setValues( values );
+        List<SMSEvent> events = new ArrayList<>();
+        subm.setEvents( events );
+
         subm.setSubmissionID( 1 );
 
         return subm;

--- a/src/test/java/org/hisp/dhis/smscompression/TestUtils.java
+++ b/src/test/java/org/hisp/dhis/smscompression/TestUtils.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 
 import org.hisp.dhis.smscompression.SMSConsts.SMSEventStatus;
 import org.hisp.dhis.smscompression.models.AggregateDatasetSMSSubmission;
@@ -136,7 +137,7 @@ public class TestUtils
         return subm;
     }
 
-    public static EnrollmentSMSSubmission createEnrollmentSubmission()
+    public static EnrollmentSMSSubmission createEnrollmentSubmissionNoEvents()
     {
         EnrollmentSMSSubmission subm = new EnrollmentSMSSubmission();
 
@@ -165,6 +166,34 @@ public class TestUtils
         return subm;
     }
 
+    public static EnrollmentSMSSubmission createEnrollmentSubmission()
+    {
+        EnrollmentSMSSubmission subm = new EnrollmentSMSSubmission();
+
+        subm.setUserID( "GOLswS44mh8" ); // Tom Wakiki (system)
+        subm.setOrgUnit( "DiszpKrYNg8" ); // Ngelehun CHC
+        subm.setTrackerProgram( "IpHINAT79UW" ); // Child Programme
+        subm.setTrackedEntityType( "nEenWmSyUEp" ); // Person
+        subm.setTrackedEntityInstance( "T2bRuLEGoVN" ); // Newly generated UID
+        subm.setEnrollment( "p7M1gUFK37W" ); // Newly generated UID
+        subm.setTimestamp( getNowWithoutMillis() );
+        ArrayList<SMSAttributeValue> values = new ArrayList<>();
+        values.add( new SMSAttributeValue( "w75KJ2mc4zz", "Harold" ) ); // First
+                                                                        // Name
+        values.add( new SMSAttributeValue( "zDhUuAYrxNC", "Smith" ) ); // Last
+                                                                       // Name
+        values.add( new SMSAttributeValue( "FO4sWYJ64LQ", "Sydney" ) ); // City
+        values.add( new SMSAttributeValue( "VqEFza8wbwA", "The Opera House" ) ); // Address
+        values.add( new SMSAttributeValue( "lZGmxYbs97q", "987123" ) ); // Unique
+                                                                        // ID
+        subm.setValues( values );
+        subm.setSubmissionID( 1 );
+
+        subm.setEvents( createEventList() );
+
+        return subm;
+    }
+
     public static TrackerEventSMSSubmission createTrackerEventSubmission()
     {
         TrackerEventSMSSubmission subm = new TrackerEventSMSSubmission();
@@ -180,8 +209,7 @@ public class TestUtils
         ArrayList<SMSDataValue> values = new ArrayList<>();
         values.add( new SMSDataValue( "HllvX50cXC0", "a3kGcGDCuk6", "10" ) ); // Apgar
                                                                               // score
-        values.add( new SMSDataValue( "HllvX50cXC0", "UXz7xuGCEhU", "500" ) ); // Weight
-                                                                               // (g)
+
         values.add( new SMSDataValue( "HllvX50cXC0", "wQLfBvPrXqq", "Others" ) ); // ARV
                                                                                   // at
                                                                                   // birth
@@ -191,6 +219,27 @@ public class TestUtils
         subm.setSubmissionID( 1 );
 
         return subm;
+    }
+
+    public static List<SMSEvent> createEventList()
+    {
+        List<SMSEvent> events = new ArrayList<>();
+        for ( int i = 1; i <= 3; i++ )
+        {
+            SMSEvent event = new SMSEvent();
+            event.setProgramStage( "A03MvHHogjR" ); // Birth
+            event.setEventStatus( SMSEventStatus.COMPLETED );
+            event.setAttributeOptionCombo( "HllvX50cXC0" ); // Default
+                                                            // catOptionCombo
+            event.setEvent( "r7M1gUFK37v" ); // New UID
+            event.setTimestamp( getNowWithoutMillis() );
+            ArrayList<SMSDataValue> values = new ArrayList<>();
+            values.add( new SMSDataValue( "HllvX50cXC0", "UXz7xuGCEhU", String.valueOf( i ) ) ); // Weight
+            event.setValues( values );
+            events.add( event );
+        }
+
+        return events;
     }
 
     public static void printSubm( SMSSubmission subm )

--- a/src/test/java/org/hisp/dhis/smscompression/TestUtils.java
+++ b/src/test/java/org/hisp/dhis/smscompression/TestUtils.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.smscompression.models.EnrollmentSMSSubmission;
 import org.hisp.dhis.smscompression.models.RelationshipSMSSubmission;
 import org.hisp.dhis.smscompression.models.SMSAttributeValue;
 import org.hisp.dhis.smscompression.models.SMSDataValue;
+import org.hisp.dhis.smscompression.models.SMSEvent;
 import org.hisp.dhis.smscompression.models.SMSSubmission;
 import org.hisp.dhis.smscompression.models.SimpleEventSMSSubmission;
 import org.hisp.dhis.smscompression.models.TrackerEventSMSSubmission;
@@ -157,6 +158,9 @@ public class TestUtils
                                                                         // ID
         subm.setValues( values );
         subm.setSubmissionID( 1 );
+
+        ArrayList<SMSEvent> events = new ArrayList<>();
+        subm.setEvents( events );
 
         return subm;
     }

--- a/src/test/java/org/hisp/dhis/smscompression/TestUtils.java
+++ b/src/test/java/org/hisp/dhis/smscompression/TestUtils.java
@@ -189,6 +189,80 @@ public class TestUtils
         return subm;
     }
 
+    // Submissions with empty values
+
+    public static SimpleEventSMSSubmission createSimpleEventSubmissionEmptyVals()
+    {
+        SimpleEventSMSSubmission subm = new SimpleEventSMSSubmission();
+
+        subm.setUserID( "GOLswS44mh8" ); // Tom Wakiki (system)
+        subm.setOrgUnit( "DiszpKrYNg8" ); // Ngelehun CHC
+        subm.setEventProgram( "lxAQ7Zs9VYR" ); // Antenatal Care Visit
+        subm.setAttributeOptionCombo( "HllvX50cXC0" ); // Default catOptionCombo
+        subm.setEvent( "l7M1gUFK37v" ); // New UID
+        subm.setEventStatus( SMSEventStatus.COMPLETED );
+        subm.setTimestamp( getNowWithoutMillis() );
+        ArrayList<SMSDataValue> values = new ArrayList<>();
+        subm.setValues( values );
+        subm.setSubmissionID( 1 );
+
+        return subm;
+    }
+
+    public static AggregateDatasetSMSSubmission createAggregateDatasetSubmissionEmptyVals()
+    {
+        AggregateDatasetSMSSubmission subm = new AggregateDatasetSMSSubmission();
+
+        subm.setUserID( "GOLswS44mh8" ); // Tom Wakiki (system)
+        subm.setOrgUnit( "DiszpKrYNg8" ); // Ngelehun CHC
+        subm.setDataSet( "Nyh6laLdBEJ" ); // IDSR Weekly
+        subm.setComplete( true );
+        subm.setAttributeOptionCombo( "HllvX50cXC0" );
+        subm.setPeriod( "2019W16" );
+        ArrayList<SMSDataValue> values = new ArrayList<>();
+        subm.setValues( values );
+        subm.setSubmissionID( 1 );
+
+        return subm;
+    }
+
+    public static EnrollmentSMSSubmission createEnrollmentSubmissionEmptyVals()
+    {
+        EnrollmentSMSSubmission subm = new EnrollmentSMSSubmission();
+
+        subm.setUserID( "GOLswS44mh8" ); // Tom Wakiki (system)
+        subm.setOrgUnit( "DiszpKrYNg8" ); // Ngelehun CHC
+        subm.setTrackerProgram( "IpHINAT79UW" ); // Child Programme
+        subm.setTrackedEntityType( "nEenWmSyUEp" ); // Person
+        subm.setTrackedEntityInstance( "T2bRuLEGoVN" ); // Newly generated UID
+        subm.setEnrollment( "p7M1gUFK37W" ); // Newly generated UID
+        subm.setTimestamp( getNowWithoutMillis() );
+        ArrayList<SMSAttributeValue> values = new ArrayList<>();
+        subm.setValues( values );
+        subm.setSubmissionID( 1 );
+
+        return subm;
+    }
+
+    public static TrackerEventSMSSubmission createTrackerEventSubmissionEmptyVals()
+    {
+        TrackerEventSMSSubmission subm = new TrackerEventSMSSubmission();
+
+        subm.setUserID( "GOLswS44mh8" ); // Tom Wakiki (system)
+        subm.setOrgUnit( "DiszpKrYNg8" ); // Ngelehun CHC
+        subm.setProgramStage( "A03MvHHogjR" ); // Birth
+        subm.setAttributeOptionCombo( "HllvX50cXC0" ); // Default catOptionCombo
+        subm.setEnrollment( "DacGG5vK1K6" ); // Test Person
+        subm.setEvent( "r7M1gUFK37v" ); // New UID
+        subm.setEventStatus( SMSEventStatus.COMPLETED );
+        subm.setTimestamp( getNowWithoutMillis() );
+        ArrayList<SMSDataValue> values = new ArrayList<>();
+        subm.setValues( values );
+        subm.setSubmissionID( 1 );
+
+        return subm;
+    }
+
     public static void printSubm( SMSSubmission subm )
     {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();

--- a/src/test/java/org/hisp/dhis/smscompression/TestVersions.java
+++ b/src/test/java/org/hisp/dhis/smscompression/TestVersions.java
@@ -1,0 +1,163 @@
+package org.hisp.dhis.smscompression;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.io.FileReader;
+
+import org.apache.commons.io.IOUtils;
+import org.hisp.dhis.smscompression.models.AggregateDatasetSMSSubmission;
+import org.hisp.dhis.smscompression.models.EnrollmentSMSSubmission;
+import org.hisp.dhis.smscompression.models.SMSMetadata;
+import org.hisp.dhis.smscompression.models.SMSSubmission;
+import org.hisp.dhis.smscompression.models.SMSSubmissionHeader;
+import org.hisp.dhis.smscompression.models.SimpleEventSMSSubmission;
+import org.hisp.dhis.smscompression.models.TrackerEventSMSSubmission;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.gson.Gson;
+
+public class TestVersions
+{
+    SMSMetadata meta;
+
+    SMSSubmissionWriter writer;
+
+    SMSSubmissionReader reader;
+
+    public String compressSubm( SMSSubmission subm, int version )
+        throws Exception
+    {
+        byte[] compressSubm = writer.compress( subm, version );
+        String comp64 = TestUtils.encBase64( compressSubm );
+        TestUtils.printBase64Subm( comp64, subm.getClass() );
+        return comp64;
+    }
+
+    public SMSSubmission decompressSubm( String comp64 )
+        throws Exception
+    {
+        byte[] decSubmBytes = TestUtils.decBase64( comp64 );
+        SMSSubmissionHeader header = reader.readHeader( decSubmBytes );
+        Assert.assertNotNull( header );
+        return reader.readSubmission( decSubmBytes, meta );
+    }
+
+    @Before
+    public void init()
+        throws Exception
+    {
+        Gson gson = new Gson();
+        String metadataJson = IOUtils.toString( new FileReader( "src/test/resources/metadata.json" ) );
+        meta = gson.fromJson( metadataJson, SMSMetadata.class );
+        writer = new SMSSubmissionWriter( meta );
+        reader = new SMSSubmissionReader();
+    }
+
+    @After
+    public void cleanup()
+    {
+
+    }
+
+    @Test
+    public void testEncDecSimpleEventVersion1()
+    {
+        try
+        {
+            SimpleEventSMSSubmission origSubm = TestUtils.createSimpleEventSubmission();
+            String comp64 = compressSubm( origSubm, 1 );
+            SimpleEventSMSSubmission decSubm = (SimpleEventSMSSubmission) decompressSubm( comp64 );
+
+            TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+            Assert.fail( e.getMessage() );
+        }
+    }
+
+    @Test
+    public void testEncDecAggregateDatasetVersion1()
+    {
+        try
+        {
+            AggregateDatasetSMSSubmission origSubm = TestUtils.createAggregateDatasetSubmission();
+            String comp64 = compressSubm( origSubm, 1 );
+            AggregateDatasetSMSSubmission decSubm = (AggregateDatasetSMSSubmission) decompressSubm( comp64 );
+
+            TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+            Assert.fail( e.getMessage() );
+        }
+    }
+
+    @Test
+    public void testEncDecEnrollmentVersion1()
+    {
+        try
+        {
+            EnrollmentSMSSubmission origSubm = TestUtils.createEnrollmentSubmission();
+            String comp64 = compressSubm( origSubm, 1 );
+            EnrollmentSMSSubmission decSubm = (EnrollmentSMSSubmission) decompressSubm( comp64 );
+
+            TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+            Assert.fail( e.getMessage() );
+        }
+    }
+
+    @Test
+    public void testEncDecTrackerEventVersion1()
+    {
+        try
+        {
+            TrackerEventSMSSubmission origSubm = TestUtils.createTrackerEventSubmission();
+            String comp64 = compressSubm( origSubm, 1 );
+            TrackerEventSMSSubmission decSubm = (TrackerEventSMSSubmission) decompressSubm( comp64 );
+
+            TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+            Assert.fail( e.getMessage() );
+        }
+    }
+
+}

--- a/src/test/java/org/hisp/dhis/smscompression/TestVersions.java
+++ b/src/test/java/org/hisp/dhis/smscompression/TestVersions.java
@@ -129,7 +129,7 @@ public class TestVersions
     {
         try
         {
-            EnrollmentSMSSubmission origSubm = TestUtils.createEnrollmentSubmission();
+            EnrollmentSMSSubmission origSubm = TestUtils.createEnrollmentSubmissionNoEvents();
             String comp64 = compressSubm( origSubm, 1 );
             EnrollmentSMSSubmission decSubm = (EnrollmentSMSSubmission) decompressSubm( comp64 );
 

--- a/src/test/java/org/hisp/dhis/smscompression/TestVersions.java
+++ b/src/test/java/org/hisp/dhis/smscompression/TestVersions.java
@@ -34,7 +34,9 @@ import java.io.FileReader;
 
 import org.apache.commons.io.IOUtils;
 import org.hisp.dhis.smscompression.models.AggregateDatasetSMSSubmission;
+import org.hisp.dhis.smscompression.models.DeleteSMSSubmission;
 import org.hisp.dhis.smscompression.models.EnrollmentSMSSubmission;
+import org.hisp.dhis.smscompression.models.RelationshipSMSSubmission;
 import org.hisp.dhis.smscompression.models.SMSMetadata;
 import org.hisp.dhis.smscompression.models.SMSSubmission;
 import org.hisp.dhis.smscompression.models.SMSSubmissionHeader;
@@ -152,6 +154,42 @@ public class TestVersions
             TrackerEventSMSSubmission origSubm = TestUtils.createTrackerEventSubmission();
             String comp64 = compressSubm( origSubm, 1 );
             TrackerEventSMSSubmission decSubm = (TrackerEventSMSSubmission) decompressSubm( comp64 );
+
+            TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+            Assert.fail( e.getMessage() );
+        }
+    }
+
+    @Test
+    public void testEncDecDeleteVersion1()
+    {
+        try
+        {
+            DeleteSMSSubmission origSubm = TestUtils.createDeleteSubmission();
+            String comp64 = compressSubm( origSubm, 1 );
+            DeleteSMSSubmission decSubm = (DeleteSMSSubmission) decompressSubm( comp64 );
+
+            TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+            Assert.fail( e.getMessage() );
+        }
+    }
+
+    @Test
+    public void testEncDecRelationshipVersion1()
+    {
+        try
+        {
+            RelationshipSMSSubmission origSubm = TestUtils.createRelationshipSubmission();
+            String comp64 = compressSubm( origSubm, 1 );
+            RelationshipSMSSubmission decSubm = (RelationshipSMSSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }

--- a/src/test/java/org/hisp/dhis/smscompression/TestVersions.java
+++ b/src/test/java/org/hisp/dhis/smscompression/TestVersions.java
@@ -1,5 +1,7 @@
 package org.hisp.dhis.smscompression;
 
+import static org.junit.Assert.assertEquals;
+
 /*
  * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
@@ -160,4 +162,79 @@ public class TestVersions
         }
     }
 
+    @Test
+    public void testWriteUnknownVersion()
+    {
+        try
+        {
+            compressSubm( TestUtils.createTrackerEventSubmission(), 0 );
+        }
+        catch ( Exception e )
+        {
+            assertEquals( e.getClass(), SMSCompressionException.class );
+            assertEquals( e.getMessage(), "Version 0 of TrackerEventSMSSubmission is not supported" );
+            return;
+        }
+
+        Assert.fail( "Expected unknown version exception not found" );
+    }
+
+    @Test
+    public void testWriteFutureVersion()
+    {
+        SMSSubmission subm = TestUtils.createTrackerEventSubmission();
+        int futureVer = subm.getCurrentVersion() + 1;
+
+        try
+        {
+            compressSubm( subm, futureVer );
+        }
+        catch ( Exception e )
+        {
+            assertEquals( e.getClass(), SMSCompressionException.class );
+            assertEquals( e.getMessage(),
+                String.format( "Version %d of TrackerEventSMSSubmission is not supported", futureVer ) );
+            return;
+        }
+
+        Assert.fail( "Expected unknown version exception not found" );
+    }
+
+    @Test
+    public void testWriteUnknownVersionRelationship()
+    {
+        try
+        {
+            compressSubm( TestUtils.createRelationshipSubmission(), 0 );
+        }
+        catch ( Exception e )
+        {
+            assertEquals( e.getClass(), SMSCompressionException.class );
+            assertEquals( e.getMessage(), "Version 0 of RelationshipSMSSubmission is not supported" );
+            return;
+        }
+
+        Assert.fail( "Expected unknown version exception not found" );
+    }
+
+    @Test
+    public void testWriteFutureVersionRelationship()
+    {
+        SMSSubmission subm = TestUtils.createRelationshipSubmission();
+        int futureVer = subm.getCurrentVersion() + 1;
+
+        try
+        {
+            compressSubm( subm, futureVer );
+        }
+        catch ( Exception e )
+        {
+            assertEquals( e.getClass(), SMSCompressionException.class );
+            assertEquals( e.getMessage(),
+                String.format( "Version %d of RelationshipSMSSubmission is not supported", futureVer ) );
+            return;
+        }
+
+        Assert.fail( "Expected unknown version exception not found" );
+    }
 }


### PR DESCRIPTION
This PR updates the EnrollmentSMSSubmission to include a list of TrackerEvents.

It also fixes an issue where it wasn't possible to have an empty list of data values in a submission.

In addition, as there are some breaking schema changes to some of the submissions, there is more stringent versioning support now. Submissions include the ability to read and write in the old and new versions.