### PR TITLE
refactor: rename all acronyms to camel case

### DIFF
--- a/src/main/java/org/hisp/dhis/smscompression/SmsCompressionException.java
+++ b/src/main/java/org/hisp/dhis/smscompression/SmsCompressionException.java
@@ -28,7 +28,7 @@ package org.hisp.dhis.smscompression;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-public class SMSCompressionException
+public class SmsCompressionException
     extends
     Exception
 {
@@ -38,17 +38,17 @@ public class SMSCompressionException
      */
     private static final long serialVersionUID = 1L;
 
-    public SMSCompressionException( String message )
+    public SmsCompressionException( String message )
     {
         super( message );
     }
 
-    public SMSCompressionException( String message, Throwable error )
+    public SmsCompressionException( String message, Throwable error )
     {
         super( message, error );
     }
 
-    public SMSCompressionException( Throwable error )
+    public SmsCompressionException( Throwable error )
     {
         super( error );
     }

--- a/src/main/java/org/hisp/dhis/smscompression/SmsConsts.java
+++ b/src/main/java/org/hisp/dhis/smscompression/SmsConsts.java
@@ -30,7 +30,7 @@ import java.text.SimpleDateFormat;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-public class SMSConsts
+public class SmsConsts
 {
 
     public enum SubmissionType
@@ -68,7 +68,7 @@ public class SMSConsts
         ;
     }
 
-    public enum SMSEventStatus
+    public enum SmsEventStatus
     {
         ACTIVE, COMPLETED, VISITED, SCHEDULE, OVERDUE, SKIPPED,
 
@@ -76,7 +76,7 @@ public class SMSConsts
 
     }
 
-    public enum SMSEnrollmentStatus
+    public enum SmsEnrollmentStatus
     {
         ACTIVE, COMPLETED, CANCELLED
 

--- a/src/main/java/org/hisp/dhis/smscompression/SmsResponse.java
+++ b/src/main/java/org/hisp/dhis/smscompression/SmsResponse.java
@@ -33,7 +33,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
-public enum SMSResponse
+public enum SmsResponse
 {
     SUCCESS( 0, "Submission has been processed successfully" ),
 
@@ -80,21 +80,21 @@ public enum SMSResponse
 
     private List<Object> errorElems;
 
-    private SMSResponse( int code, String description )
+    private SmsResponse( int code, String description )
     {
         this.code = code;
         this.description = description;
         this.errorElems = new ArrayList<Object>();
     }
 
-    public SMSResponse set( Object... elems )
+    public SmsResponse set( Object... elems )
     {
         this.errorElems = Arrays.asList( elems );
         this.description = String.format( description, elems );
         return this;
     }
 
-    public SMSResponse setList( List<Object> elems )
+    public SmsResponse setList( List<Object> elems )
     {
         this.errorElems = elems;
         this.description = String.format( description, errorElems.toArray() );

--- a/src/main/java/org/hisp/dhis/smscompression/SmsSubmissionReader.java
+++ b/src/main/java/org/hisp/dhis/smscompression/SmsSubmissionReader.java
@@ -37,84 +37,84 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
-import org.hisp.dhis.smscompression.SMSConsts.MetadataType;
-import org.hisp.dhis.smscompression.SMSConsts.SMSEnrollmentStatus;
-import org.hisp.dhis.smscompression.SMSConsts.SMSEventStatus;
-import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
-import org.hisp.dhis.smscompression.models.AggregateDatasetSMSSubmission;
-import org.hisp.dhis.smscompression.models.DeleteSMSSubmission;
-import org.hisp.dhis.smscompression.models.EnrollmentSMSSubmission;
+import org.hisp.dhis.smscompression.SmsConsts.MetadataType;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEnrollmentStatus;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEventStatus;
+import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
+import org.hisp.dhis.smscompression.models.AggregateDatasetSmsSubmission;
+import org.hisp.dhis.smscompression.models.DeleteSmsSubmission;
+import org.hisp.dhis.smscompression.models.EnrollmentSmsSubmission;
 import org.hisp.dhis.smscompression.models.GeoPoint;
-import org.hisp.dhis.smscompression.models.RelationshipSMSSubmission;
-import org.hisp.dhis.smscompression.models.SMSAttributeValue;
-import org.hisp.dhis.smscompression.models.SMSDataValue;
-import org.hisp.dhis.smscompression.models.SMSEvent;
-import org.hisp.dhis.smscompression.models.SMSMetadata;
-import org.hisp.dhis.smscompression.models.SMSSubmission;
-import org.hisp.dhis.smscompression.models.SMSSubmissionHeader;
-import org.hisp.dhis.smscompression.models.SimpleEventSMSSubmission;
-import org.hisp.dhis.smscompression.models.TrackerEventSMSSubmission;
-import org.hisp.dhis.smscompression.models.UID;
+import org.hisp.dhis.smscompression.models.RelationshipSmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsAttributeValue;
+import org.hisp.dhis.smscompression.models.SmsDataValue;
+import org.hisp.dhis.smscompression.models.SmsEvent;
+import org.hisp.dhis.smscompression.models.SmsMetadata;
+import org.hisp.dhis.smscompression.models.SmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsSubmissionHeader;
+import org.hisp.dhis.smscompression.models.SimpleEventSmsSubmission;
+import org.hisp.dhis.smscompression.models.TrackerEventSmsSubmission;
+import org.hisp.dhis.smscompression.models.Uid;
 import org.hisp.dhis.smscompression.utils.BitInputStream;
-import org.hisp.dhis.smscompression.utils.IDUtil;
+import org.hisp.dhis.smscompression.utils.IdUtil;
 import org.hisp.dhis.smscompression.utils.ValueUtil;
 
-public class SMSSubmissionReader
+public class SmsSubmissionReader
 {
     BitInputStream inStream;
 
-    SMSMetadata meta;
+    SmsMetadata meta;
 
     ValueReader valueReader;
 
-    public SMSSubmissionHeader readHeader( byte[] smsBytes )
-        throws SMSCompressionException
+    public SmsSubmissionHeader readHeader( byte[] smsBytes )
+        throws SmsCompressionException
     {
-        if ( !checkCRC( smsBytes ) )
-            throw new SMSCompressionException( "Invalid CRC - CRC in header does not match submission" );
+        if ( !checkCrc( smsBytes ) )
+            throw new SmsCompressionException( "Invalid CRC - CRC in header does not match submission" );
 
         ByteArrayInputStream byteStream = new ByteArrayInputStream( smsBytes );
         this.inStream = new BitInputStream( byteStream );
-        inStream.read( SMSConsts.CRC_BITLEN ); // skip CRC
+        inStream.read( SmsConsts.CRC_BITLEN ); // skip CRC
 
-        SMSSubmissionHeader header = new SMSSubmissionHeader();
+        SmsSubmissionHeader header = new SmsSubmissionHeader();
         header.readHeader( this );
 
         return header;
     }
 
-    public SMSSubmission readSubmission( byte[] smsBytes, SMSMetadata meta )
-        throws SMSCompressionException
+    public SmsSubmission readSubmission( byte[] smsBytes, SmsMetadata meta )
+        throws SmsCompressionException
     {
         if ( meta != null )
             meta.validate();
         this.meta = meta;
-        SMSSubmissionHeader header = readHeader( smsBytes );
+        SmsSubmissionHeader header = readHeader( smsBytes );
         this.valueReader = new ValueReader( inStream, meta );
-        SMSSubmission subm = null;
+        SmsSubmission subm = null;
 
         switch ( header.getType() )
         {
         case AGGREGATE_DATASET:
-            subm = new AggregateDatasetSMSSubmission();
+            subm = new AggregateDatasetSmsSubmission();
             break;
         case DELETE:
-            subm = new DeleteSMSSubmission();
+            subm = new DeleteSmsSubmission();
             break;
         case ENROLLMENT:
-            subm = new EnrollmentSMSSubmission();
+            subm = new EnrollmentSmsSubmission();
             break;
         case RELATIONSHIP:
-            subm = new RelationshipSMSSubmission();
+            subm = new RelationshipSmsSubmission();
             break;
         case SIMPLE_EVENT:
-            subm = new SimpleEventSMSSubmission();
+            subm = new SimpleEventSmsSubmission();
             break;
         case TRACKER_EVENT:
-            subm = new TrackerEventSMSSubmission();
+            subm = new TrackerEventSmsSubmission();
             break;
         default:
-            throw new SMSCompressionException( "Unknown SMS Submission Type: " + header.getType() );
+            throw new SmsCompressionException( "Unknown SMS Submission Type: " + header.getType() );
         }
 
         subm.read( this, header );
@@ -124,12 +124,12 @@ public class SMSSubmissionReader
         }
         catch ( IOException e )
         {
-            throw new SMSCompressionException( e );
+            throw new SmsCompressionException( e );
         }
         return subm;
     }
 
-    private boolean checkCRC( byte[] smsBytes )
+    private boolean checkCrc( byte[] smsBytes )
     {
         byte crc = smsBytes[0];
         byte[] submBytes = Arrays.copyOfRange( smsBytes, 1, smsBytes.length );
@@ -137,8 +137,8 @@ public class SMSSubmissionReader
         try
         {
             MessageDigest digest = MessageDigest.getInstance( "SHA-256" );
-            byte[] calcCRC = digest.digest( submBytes );
-            return (calcCRC[0] == crc);
+            byte[] calcCrc = digest.digest( submBytes );
+            return (calcCrc[0] == crc);
         }
         catch ( NoSuchAlgorithmException e )
         {
@@ -148,26 +148,26 @@ public class SMSSubmissionReader
     }
 
     public SubmissionType readType()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
-        int submType = inStream.read( SMSConsts.SUBM_TYPE_BITLEN );
-        return SMSConsts.SubmissionType.values()[submType];
+        int submType = inStream.read( SmsConsts.SUBM_TYPE_BITLEN );
+        return SmsConsts.SubmissionType.values()[submType];
     }
 
     public int readVersion()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
-        return inStream.read( SMSConsts.VERSION_BITLEN );
+        return inStream.read( SmsConsts.VERSION_BITLEN );
     }
 
     public Date readNonNullableDate()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         return ValueUtil.readDate( inStream );
     }
 
     public Date readDate()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         boolean hasDate = readBool();
         if ( !hasDate )
@@ -178,67 +178,67 @@ public class SMSSubmissionReader
         return ValueUtil.readDate( inStream );
     }
 
-    public UID readID( MetadataType type )
-        throws SMSCompressionException
+    public Uid readId( MetadataType type )
+        throws SmsCompressionException
     {
-        return IDUtil.readID( type, meta, inStream );
+        return IdUtil.readId( type, meta, inStream );
     }
 
-    public String readNewID()
-        throws SMSCompressionException
+    public String readNewId()
+        throws SmsCompressionException
     {
-        return IDUtil.readNewID( inStream );
+        return IdUtil.readNewId( inStream );
     }
 
-    public List<SMSAttributeValue> readAttributeValues()
-        throws SMSCompressionException
+    public List<SmsAttributeValue> readAttributeValues()
+        throws SmsCompressionException
     {
         return valueReader.readAttributeValues();
     }
 
-    public List<SMSDataValue> readDataValues()
-        throws SMSCompressionException
+    public List<SmsDataValue> readDataValues()
+        throws SmsCompressionException
     {
         return valueReader.readDataValues();
     }
 
     public boolean readBool()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         return ValueUtil.readBool( inStream );
     }
 
     // TODO: Update this once we have a better impl of period
     public String readPeriod()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         return ValueUtil.readString( inStream );
     }
 
-    public int readSubmissionID()
-        throws SMSCompressionException
+    public int readSubmissionId()
+        throws SmsCompressionException
     {
-        return inStream.read( SMSConsts.SUBM_ID_BITLEN );
+        return inStream.read( SmsConsts.SUBM_ID_BITLEN );
     }
 
-    public SMSEventStatus readEventStatus()
-        throws SMSCompressionException
+    public SmsEventStatus readEventStatus()
+        throws SmsCompressionException
     {
-        int eventStatusNum = inStream.read( SMSConsts.EVENT_STATUS_BITLEN );
-        return SMSEventStatus.values()[eventStatusNum];
+        int eventStatusNum = inStream.read( SmsConsts.EVENT_STATUS_BITLEN );
+        return SmsEventStatus.values()[eventStatusNum];
     }
 
-    public List<SMSEvent> readEvents( int version )
-        throws SMSCompressionException
+    public List<SmsEvent> readEvents( int version )
+        throws SmsCompressionException
     {
         boolean hasEvents = readBool();
-        ArrayList<SMSEvent> events = null;
+        ArrayList<SmsEvent> events = null;
         if ( hasEvents )
         {
             events = new ArrayList<>();
             for ( boolean hasNext = true; hasNext; hasNext = readBool() )
             {
-                SMSEvent event = new SMSEvent();
+                SmsEvent event = new SmsEvent();
                 event.readEvent( this, version );
                 events.add( event );
             }
@@ -248,7 +248,7 @@ public class SMSSubmissionReader
     }
 
     public GeoPoint readGeoPoint()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         GeoPoint gp = null;
         boolean hasGeoPoint = readBool();
@@ -262,10 +262,10 @@ public class SMSSubmissionReader
         return gp;
     }
 
-    public SMSEnrollmentStatus readEnrollmentStatus()
-        throws SMSCompressionException
+    public SmsEnrollmentStatus readEnrollmentStatus()
+        throws SmsCompressionException
     {
-        int enrollStatusNum = inStream.read( SMSConsts.ENROL_STATUS_BITLEN );
-        return SMSEnrollmentStatus.values()[enrollStatusNum];
+        int enrollStatusNum = inStream.read( SmsConsts.ENROL_STATUS_BITLEN );
+        return SmsEnrollmentStatus.values()[enrollStatusNum];
     }
 }

--- a/src/main/java/org/hisp/dhis/smscompression/SmsSubmissionWriter.java
+++ b/src/main/java/org/hisp/dhis/smscompression/SmsSubmissionWriter.java
@@ -36,35 +36,35 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
-import org.hisp.dhis.smscompression.SMSConsts.SMSEnrollmentStatus;
-import org.hisp.dhis.smscompression.SMSConsts.SMSEventStatus;
-import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEnrollmentStatus;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEventStatus;
+import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
 import org.hisp.dhis.smscompression.models.GeoPoint;
-import org.hisp.dhis.smscompression.models.SMSAttributeValue;
-import org.hisp.dhis.smscompression.models.SMSDataValue;
-import org.hisp.dhis.smscompression.models.SMSEvent;
-import org.hisp.dhis.smscompression.models.SMSMetadata;
-import org.hisp.dhis.smscompression.models.SMSSubmission;
-import org.hisp.dhis.smscompression.models.UID;
+import org.hisp.dhis.smscompression.models.SmsAttributeValue;
+import org.hisp.dhis.smscompression.models.SmsDataValue;
+import org.hisp.dhis.smscompression.models.SmsEvent;
+import org.hisp.dhis.smscompression.models.SmsMetadata;
+import org.hisp.dhis.smscompression.models.SmsSubmission;
+import org.hisp.dhis.smscompression.models.Uid;
 import org.hisp.dhis.smscompression.utils.BitOutputStream;
-import org.hisp.dhis.smscompression.utils.IDUtil;
+import org.hisp.dhis.smscompression.utils.IdUtil;
 import org.hisp.dhis.smscompression.utils.ValueUtil;
 
-public class SMSSubmissionWriter
+public class SmsSubmissionWriter
 {
     ByteArrayOutputStream byteStream;
 
     BitOutputStream outStream;
 
-    SMSMetadata meta;
+    SmsMetadata meta;
 
     ValueWriter valueWriter;
 
     // By default we enable hashing but it can be disabled
     boolean hashingEnabled = true;
 
-    public SMSSubmissionWriter( SMSMetadata meta )
-        throws SMSCompressionException
+    public SmsSubmissionWriter( SmsMetadata meta )
+        throws SmsCompressionException
     {
         if ( meta != null )
             meta.validate();
@@ -81,14 +81,14 @@ public class SMSSubmissionWriter
         this.hashingEnabled = useHashing;
     }
 
-    public byte[] compress( SMSSubmission subm )
-        throws SMSCompressionException
+    public byte[] compress( SmsSubmission subm )
+        throws SmsCompressionException
     {
         return compress( subm, subm.getCurrentVersion() );
     }
 
-    public byte[] compress( SMSSubmission subm, int version )
-        throws SMSCompressionException
+    public byte[] compress( SmsSubmission subm, int version )
+        throws SmsCompressionException
     {
         this.byteStream = new ByteArrayOutputStream();
         this.outStream = new BitOutputStream( byteStream );
@@ -100,29 +100,29 @@ public class SMSSubmissionWriter
     }
 
     public byte[] toByteArray()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         try
         {
             outStream.close();
             byte[] subm = byteStream.toByteArray();
-            byte[] crcSubm = writeCRC( subm );
+            byte[] crcSubm = writeCrc( subm );
             return crcSubm;
         }
         catch ( IOException e )
         {
-            throw new SMSCompressionException( e );
+            throw new SmsCompressionException( e );
         }
     }
 
-    public byte[] writeCRC( byte[] subm )
+    public byte[] writeCrc( byte[] subm )
     {
         byte crc;
         try
         {
             MessageDigest digest = MessageDigest.getInstance( "SHA-256" );
-            byte[] calcCRC = digest.digest( subm );
-            crc = calcCRC[0];
+            byte[] calcCrc = digest.digest( subm );
+            crc = calcCrc[0];
         }
         catch ( NoSuchAlgorithmException e )
         {
@@ -138,25 +138,25 @@ public class SMSSubmissionWriter
     }
 
     public void writeType( SubmissionType type )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
-        outStream.write( type.ordinal(), SMSConsts.SUBM_TYPE_BITLEN );
+        outStream.write( type.ordinal(), SmsConsts.SUBM_TYPE_BITLEN );
     }
 
     public void writeVersion( int version )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
-        outStream.write( version, SMSConsts.VERSION_BITLEN );
+        outStream.write( version, SmsConsts.VERSION_BITLEN );
     }
 
     public void writeNonNullableDate( Date date )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         ValueUtil.writeDate( date, outStream );
     }
 
     public void writeDate( Date date )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         writeBool( date != null );
         if ( date != null )
@@ -165,32 +165,32 @@ public class SMSSubmissionWriter
         }
     }
 
-    public void writeID( UID uid )
-        throws SMSCompressionException
+    public void writeId( Uid uid )
+        throws SmsCompressionException
     {
-        IDUtil.writeID( uid, hashingEnabled, meta, outStream );
+        IdUtil.writeId( uid, hashingEnabled, meta, outStream );
     }
 
-    public void writeNewID( String id )
-        throws SMSCompressionException
+    public void writeNewId( String id )
+        throws SmsCompressionException
     {
-        IDUtil.writeNewID( id, outStream );
+        IdUtil.writeNewId( id, outStream );
     }
 
-    public void writeAttributeValues( List<SMSAttributeValue> values )
-        throws SMSCompressionException
+    public void writeAttributeValues( List<SmsAttributeValue> values )
+        throws SmsCompressionException
     {
         valueWriter.writeAttributeValues( values );
     }
 
-    public void writeDataValues( List<SMSDataValue> values )
-        throws SMSCompressionException
+    public void writeDataValues( List<SmsDataValue> values )
+        throws SmsCompressionException
     {
         valueWriter.writeDataValues( values );
     }
 
     public void writeBool( boolean val )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         ValueUtil.writeBool( val, outStream );
     }
@@ -198,33 +198,33 @@ public class SMSSubmissionWriter
     // TODO: We should consider a better implementation for period than just
     // String
     public void writePeriod( String period )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         ValueUtil.writeString( period, outStream );
     }
 
-    public void writeSubmissionID( int submissionID )
-        throws SMSCompressionException
+    public void writeSubmissionId( int submissionId )
+        throws SmsCompressionException
     {
-        outStream.write( submissionID, SMSConsts.SUBM_ID_BITLEN );
+        outStream.write( submissionId, SmsConsts.SUBM_ID_BITLEN );
     }
 
-    public void writeEventStatus( SMSEventStatus eventStatus )
-        throws SMSCompressionException
+    public void writeEventStatus( SmsEventStatus eventStatus )
+        throws SmsCompressionException
     {
-        outStream.write( eventStatus.ordinal(), SMSConsts.EVENT_STATUS_BITLEN );
+        outStream.write( eventStatus.ordinal(), SmsConsts.EVENT_STATUS_BITLEN );
     }
 
-    public void writeEvents( List<SMSEvent> events, int version )
-        throws SMSCompressionException
+    public void writeEvents( List<SmsEvent> events, int version )
+        throws SmsCompressionException
     {
         boolean hasEvents = (events != null && !events.isEmpty());
         writeBool( hasEvents );
         if ( hasEvents )
         {
-            for ( Iterator<SMSEvent> eventIter = events.iterator(); eventIter.hasNext(); )
+            for ( Iterator<SmsEvent> eventIter = events.iterator(); eventIter.hasNext(); )
             {
-                SMSEvent event = eventIter.next();
+                SmsEvent event = eventIter.next();
                 event.writeEvent( this, version );
                 writeBool( eventIter.hasNext() );
             }
@@ -232,7 +232,7 @@ public class SMSSubmissionWriter
     }
 
     public void writeGeoPoint( GeoPoint coordinates )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         writeBool( coordinates != null );
         if ( coordinates != null )
@@ -242,9 +242,9 @@ public class SMSSubmissionWriter
         }
     }
 
-    public void writeEnrollmentStatus( SMSEnrollmentStatus enrollmentStatus )
-        throws SMSCompressionException
+    public void writeEnrollmentStatus( SmsEnrollmentStatus enrollmentStatus )
+        throws SmsCompressionException
     {
-        outStream.write( enrollmentStatus.ordinal(), SMSConsts.ENROL_STATUS_BITLEN );
+        outStream.write( enrollmentStatus.ordinal(), SmsConsts.ENROL_STATUS_BITLEN );
     }
 }

--- a/src/main/java/org/hisp/dhis/smscompression/ValueReader.java
+++ b/src/main/java/org/hisp/dhis/smscompression/ValueReader.java
@@ -4,46 +4,46 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.hisp.dhis.smscompression.SMSConsts.MetadataType;
-import org.hisp.dhis.smscompression.models.SMSAttributeValue;
-import org.hisp.dhis.smscompression.models.SMSDataValue;
-import org.hisp.dhis.smscompression.models.SMSMetadata;
-import org.hisp.dhis.smscompression.models.SMSValue;
-import org.hisp.dhis.smscompression.models.UID;
+import org.hisp.dhis.smscompression.SmsConsts.MetadataType;
+import org.hisp.dhis.smscompression.models.SmsAttributeValue;
+import org.hisp.dhis.smscompression.models.SmsDataValue;
+import org.hisp.dhis.smscompression.models.SmsMetadata;
+import org.hisp.dhis.smscompression.models.SmsValue;
+import org.hisp.dhis.smscompression.models.Uid;
 import org.hisp.dhis.smscompression.utils.BitInputStream;
-import org.hisp.dhis.smscompression.utils.IDUtil;
+import org.hisp.dhis.smscompression.utils.IdUtil;
 import org.hisp.dhis.smscompression.utils.ValueUtil;
 
 public class ValueReader
 {
     BitInputStream inStream;
 
-    SMSMetadata meta;
+    SmsMetadata meta;
 
     boolean hashingEnabled;
 
-    public ValueReader( BitInputStream inStream, SMSMetadata meta )
+    public ValueReader( BitInputStream inStream, SmsMetadata meta )
     {
         this.inStream = inStream;
         this.meta = meta;
     }
 
-    public UID readValID( int bitLen, Map<Integer, String> idLookup, MetadataType type )
-        throws SMSCompressionException
+    public Uid readValId( int bitLen, Map<Integer, String> idLookup, MetadataType type )
+        throws SmsCompressionException
     {
         if ( !hashingEnabled )
-            return new UID( ValueUtil.readString( inStream ), type );
+            return new Uid( ValueUtil.readString( inStream ), type );
 
         String id;
         int idHash = inStream.read( bitLen );
         id = idLookup.get( idHash );
-        return new UID( id, idHash, type );
+        return new Uid( id, idHash, type );
     }
 
-    public List<SMSAttributeValue> readAttributeValues()
-        throws SMSCompressionException
+    public List<SmsAttributeValue> readAttributeValues()
+        throws SmsCompressionException
     {
-        ArrayList<SMSAttributeValue> values = new ArrayList<>();
+        ArrayList<SmsAttributeValue> values = new ArrayList<>();
         MetadataType type = MetadataType.TRACKED_ENTITY_ATTRIBUTE;
         int attributeBitLen = 0;
         Map<Integer, String> idLookup = null;
@@ -51,23 +51,23 @@ public class ValueReader
         this.hashingEnabled = ValueUtil.readBool( inStream );
         if ( hashingEnabled )
         {
-            attributeBitLen = inStream.read( SMSConsts.VARLEN_BITLEN );
-            idLookup = IDUtil.getIDLookup( meta.getType( type ), attributeBitLen );
+            attributeBitLen = inStream.read( SmsConsts.VARLEN_BITLEN );
+            idLookup = IdUtil.getIdLookup( meta.getType( type ), attributeBitLen );
         }
-        int fixedIntBitLen = inStream.read( SMSConsts.FIXED_INT_BITLEN ) + 1;
+        int fixedIntBitLen = inStream.read( SmsConsts.FIXED_INT_BITLEN ) + 1;
 
         for ( int valSep = 1; valSep == 1; valSep = inStream.read( 1 ) )
         {
-            UID id = readValID( attributeBitLen, idLookup, type );
-            SMSValue<?> smsValue = ValueUtil.readSMSValue( fixedIntBitLen, inStream );
-            values.add( new SMSAttributeValue( id, smsValue ) );
+            Uid id = readValId( attributeBitLen, idLookup, type );
+            SmsValue<?> smsValue = ValueUtil.readSmsValue( fixedIntBitLen, inStream );
+            values.add( new SmsAttributeValue( id, smsValue ) );
         }
 
         return values;
     }
 
-    public List<SMSDataValue> readDataValues()
-        throws SMSCompressionException
+    public List<SmsDataValue> readDataValues()
+        throws SmsCompressionException
     {
         int catOptionComboBitLen = 0;
         int dataElementBitLen = 0;
@@ -79,24 +79,24 @@ public class ValueReader
         this.hashingEnabled = ValueUtil.readBool( inStream );
         if ( hashingEnabled )
         {
-            catOptionComboBitLen = inStream.read( SMSConsts.VARLEN_BITLEN );
-            cocIDLookup = IDUtil.getIDLookup( meta.getType( cocType ), catOptionComboBitLen );
+            catOptionComboBitLen = inStream.read( SmsConsts.VARLEN_BITLEN );
+            cocIDLookup = IdUtil.getIdLookup( meta.getType( cocType ), catOptionComboBitLen );
 
-            dataElementBitLen = inStream.read( SMSConsts.VARLEN_BITLEN );
-            deIDLookup = IDUtil.getIDLookup( meta.getType( deType ), dataElementBitLen );
+            dataElementBitLen = inStream.read( SmsConsts.VARLEN_BITLEN );
+            deIDLookup = IdUtil.getIdLookup( meta.getType( deType ), dataElementBitLen );
         }
-        int fixedIntBitLen = inStream.read( SMSConsts.FIXED_INT_BITLEN ) + 1;
-        ArrayList<SMSDataValue> values = new ArrayList<>();
+        int fixedIntBitLen = inStream.read( SmsConsts.FIXED_INT_BITLEN ) + 1;
+        ArrayList<SmsDataValue> values = new ArrayList<>();
 
         for ( int cocSep = 1; cocSep == 1; cocSep = inStream.read( 1 ) )
         {
-            UID catOptionCombo = readValID( catOptionComboBitLen, cocIDLookup, cocType );
+            Uid catOptionCombo = readValId( catOptionComboBitLen, cocIDLookup, cocType );
 
             for ( int valSep = 1; valSep == 1; valSep = inStream.read( 1 ) )
             {
-                UID dataElement = readValID( dataElementBitLen, deIDLookup, deType );
-                SMSValue<?> smsValue = ValueUtil.readSMSValue( fixedIntBitLen, inStream );
-                values.add( new SMSDataValue( catOptionCombo, dataElement, smsValue ) );
+                Uid dataElement = readValId( dataElementBitLen, deIDLookup, deType );
+                SmsValue<?> smsValue = ValueUtil.readSmsValue( fixedIntBitLen, inStream );
+                values.add( new SmsDataValue( catOptionCombo, dataElement, smsValue ) );
             }
         }
 

--- a/src/main/java/org/hisp/dhis/smscompression/models/AggregateDatasetSmsSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/AggregateDatasetSmsSubmission.java
@@ -31,49 +31,49 @@ package org.hisp.dhis.smscompression.models;
 import java.util.List;
 import java.util.Objects;
 
-import org.hisp.dhis.smscompression.SMSCompressionException;
-import org.hisp.dhis.smscompression.SMSConsts;
-import org.hisp.dhis.smscompression.SMSConsts.MetadataType;
-import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
-import org.hisp.dhis.smscompression.SMSSubmissionReader;
-import org.hisp.dhis.smscompression.SMSSubmissionWriter;
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.SmsConsts;
+import org.hisp.dhis.smscompression.SmsConsts.MetadataType;
+import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
+import org.hisp.dhis.smscompression.SmsSubmissionReader;
+import org.hisp.dhis.smscompression.SmsSubmissionWriter;
 
-public class AggregateDatasetSMSSubmission
+public class AggregateDatasetSmsSubmission
     extends
-    SMSSubmission
+    SmsSubmission
 {
-    protected UID orgUnit;
+    protected Uid orgUnit;
 
-    protected UID dataSet;
+    protected Uid dataSet;
 
     protected boolean complete;
 
-    protected UID attributeOptionCombo;
+    protected Uid attributeOptionCombo;
 
     protected String period;
 
-    protected List<SMSDataValue> values;
+    protected List<SmsDataValue> values;
 
     /* Getters and Setters */
 
-    public UID getOrgUnit()
+    public Uid getOrgUnit()
     {
         return orgUnit;
     }
 
     public void setOrgUnit( String orgUnit )
     {
-        this.orgUnit = new UID( orgUnit, MetadataType.ORGANISATION_UNIT );
+        this.orgUnit = new Uid( orgUnit, MetadataType.ORGANISATION_UNIT );
     }
 
-    public UID getDataSet()
+    public Uid getDataSet()
     {
         return dataSet;
     }
 
     public void setDataSet( String dataSet )
     {
-        this.dataSet = new UID( dataSet, MetadataType.DATASET );
+        this.dataSet = new Uid( dataSet, MetadataType.DATASET );
     }
 
     public boolean isComplete()
@@ -86,14 +86,14 @@ public class AggregateDatasetSMSSubmission
         this.complete = complete;
     }
 
-    public UID getAttributeOptionCombo()
+    public Uid getAttributeOptionCombo()
     {
         return attributeOptionCombo;
     }
 
     public void setAttributeOptionCombo( String attributeOptionCombo )
     {
-        this.attributeOptionCombo = new UID( attributeOptionCombo, MetadataType.CATEGORY_OPTION_COMBO );
+        this.attributeOptionCombo = new Uid( attributeOptionCombo, MetadataType.CATEGORY_OPTION_COMBO );
     }
 
     public String getPeriod()
@@ -106,12 +106,12 @@ public class AggregateDatasetSMSSubmission
         this.period = period;
     }
 
-    public List<SMSDataValue> getValues()
+    public List<SmsDataValue> getValues()
     {
         return values;
     }
 
-    public void setValues( List<SMSDataValue> values )
+    public void setValues( List<SmsDataValue> values )
     {
         this.values = values;
     }
@@ -123,7 +123,7 @@ public class AggregateDatasetSMSSubmission
         {
             return false;
         }
-        AggregateDatasetSMSSubmission subm = (AggregateDatasetSMSSubmission) o;
+        AggregateDatasetSmsSubmission subm = (AggregateDatasetSmsSubmission) o;
 
         return Objects.equals( orgUnit, subm.orgUnit ) && Objects.equals( dataSet, subm.dataSet )
             && Objects.equals( complete, subm.complete )
@@ -134,8 +134,8 @@ public class AggregateDatasetSMSSubmission
     /* Implementation of abstract methods */
 
     @Override
-    public void writeSubm( SMSSubmissionWriter writer, int version )
-        throws SMSCompressionException
+    public void writeSubm( SmsSubmissionWriter writer, int version )
+        throws SmsCompressionException
     {
         switch ( version )
         {
@@ -146,28 +146,28 @@ public class AggregateDatasetSMSSubmission
             writeSubmV2( writer );
             break;
         default:
-            throw new SMSCompressionException( versionError( version ) );
+            throw new SmsCompressionException( versionError( version ) );
         }
     }
 
-    private void writeSubmV1( SMSSubmissionWriter writer )
-        throws SMSCompressionException
+    private void writeSubmV1( SmsSubmissionWriter writer )
+        throws SmsCompressionException
     {
-        writer.writeID( orgUnit );
-        writer.writeID( dataSet );
+        writer.writeId( orgUnit );
+        writer.writeId( dataSet );
         writer.writeBool( complete );
-        writer.writeID( attributeOptionCombo );
+        writer.writeId( attributeOptionCombo );
         writer.writePeriod( period );
         writer.writeDataValues( values );
     }
 
-    private void writeSubmV2( SMSSubmissionWriter writer )
-        throws SMSCompressionException
+    private void writeSubmV2( SmsSubmissionWriter writer )
+        throws SmsCompressionException
     {
-        writer.writeID( orgUnit );
-        writer.writeID( dataSet );
+        writer.writeId( orgUnit );
+        writer.writeId( dataSet );
         writer.writeBool( complete );
-        writer.writeID( attributeOptionCombo );
+        writer.writeId( attributeOptionCombo );
         writer.writePeriod( period );
         boolean hasValues = (values != null && !values.isEmpty());
         writer.writeBool( hasValues );
@@ -178,8 +178,8 @@ public class AggregateDatasetSMSSubmission
     }
 
     @Override
-    public void readSubm( SMSSubmissionReader reader, int version )
-        throws SMSCompressionException
+    public void readSubm( SmsSubmissionReader reader, int version )
+        throws SmsCompressionException
     {
         switch ( version )
         {
@@ -190,28 +190,28 @@ public class AggregateDatasetSMSSubmission
             readSubmV2( reader );
             break;
         default:
-            throw new SMSCompressionException( versionError( version ) );
+            throw new SmsCompressionException( versionError( version ) );
         }
     }
 
-    private void readSubmV1( SMSSubmissionReader reader )
-        throws SMSCompressionException
+    private void readSubmV1( SmsSubmissionReader reader )
+        throws SmsCompressionException
     {
-        this.orgUnit = reader.readID( MetadataType.ORGANISATION_UNIT );
-        this.dataSet = reader.readID( MetadataType.DATASET );
+        this.orgUnit = reader.readId( MetadataType.ORGANISATION_UNIT );
+        this.dataSet = reader.readId( MetadataType.DATASET );
         this.complete = reader.readBool();
-        this.attributeOptionCombo = reader.readID( MetadataType.CATEGORY_OPTION_COMBO );
+        this.attributeOptionCombo = reader.readId( MetadataType.CATEGORY_OPTION_COMBO );
         this.period = reader.readPeriod();
         this.values = reader.readDataValues();
     }
 
-    private void readSubmV2( SMSSubmissionReader reader )
-        throws SMSCompressionException
+    private void readSubmV2( SmsSubmissionReader reader )
+        throws SmsCompressionException
     {
-        this.orgUnit = reader.readID( MetadataType.ORGANISATION_UNIT );
-        this.dataSet = reader.readID( MetadataType.DATASET );
+        this.orgUnit = reader.readId( MetadataType.ORGANISATION_UNIT );
+        this.dataSet = reader.readId( MetadataType.DATASET );
         this.complete = reader.readBool();
-        this.attributeOptionCombo = reader.readID( MetadataType.CATEGORY_OPTION_COMBO );
+        this.attributeOptionCombo = reader.readId( MetadataType.CATEGORY_OPTION_COMBO );
         this.period = reader.readPeriod();
         boolean hasValues = reader.readBool();
         this.values = hasValues ? reader.readDataValues() : null;
@@ -226,6 +226,6 @@ public class AggregateDatasetSMSSubmission
     @Override
     public SubmissionType getType()
     {
-        return SMSConsts.SubmissionType.AGGREGATE_DATASET;
+        return SmsConsts.SubmissionType.AGGREGATE_DATASET;
     }
 }

--- a/src/main/java/org/hisp/dhis/smscompression/models/DeleteSmsSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/DeleteSmsSubmission.java
@@ -1,6 +1,6 @@
 package org.hisp.dhis.smscompression.models;
 
-import org.hisp.dhis.smscompression.SMSConsts.MetadataType;
+import java.util.Objects;
 
 /*
  * Copyright (c) 2004-2019, University of Oslo
@@ -30,73 +30,75 @@ import org.hisp.dhis.smscompression.SMSConsts.MetadataType;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-public class SMSDataValue
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.SmsConsts;
+import org.hisp.dhis.smscompression.SmsConsts.MetadataType;
+import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
+import org.hisp.dhis.smscompression.SmsSubmissionReader;
+import org.hisp.dhis.smscompression.SmsSubmissionWriter;
+
+public class DeleteSmsSubmission
+    extends
+    SmsSubmission
 {
-    protected UID categoryOptionCombo;
+    protected Uid event;
 
-    protected UID dataElement;
+    /* Getters and Setters */
 
-    protected String value;
-
-    protected SMSValue<?> smsValue;
-
-    public SMSDataValue( String categoryOptionCombo, String dataElement, String value )
+    public Uid getEvent()
     {
-        this.categoryOptionCombo = new UID( categoryOptionCombo, MetadataType.CATEGORY_OPTION_COMBO );
-        this.dataElement = new UID( dataElement, MetadataType.DATA_ELEMENT );
-        this.value = value;
-        this.smsValue = SMSValue.asSMSValue( value );
+        return event;
     }
 
-    public SMSDataValue( UID categoryOptionCombo, UID dataElement, SMSValue<?> smsValue )
+    public void setEvent( String event )
     {
-        this.categoryOptionCombo = categoryOptionCombo;
-        this.dataElement = dataElement;
-        this.smsValue = smsValue;
-        // TODO: We probably need better handling than just toString() here
-        this.value = smsValue.getValue().toString();
-    }
-
-    public UID getCategoryOptionCombo()
-    {
-        return categoryOptionCombo;
-    }
-
-    public UID getDataElement()
-    {
-        return dataElement;
-    }
-
-    public String getValue()
-    {
-        return value;
-    }
-
-    public SMSValue<?> getSMSValue()
-    {
-        return smsValue;
+        this.event = new Uid( event, MetadataType.EVENT );
     }
 
     @Override
     public boolean equals( Object o )
     {
-        if ( this == o )
-        {
-            return true;
-        }
-        if ( o == null || getClass() != o.getClass() )
+        if ( !super.equals( o ) )
         {
             return false;
         }
-        SMSDataValue dv = (SMSDataValue) o;
+        DeleteSmsSubmission subm = (DeleteSmsSubmission) o;
+        return Objects.equals( event, subm.event );
+    }
 
-        return categoryOptionCombo.equals( dv.categoryOptionCombo ) && dataElement.equals( dv.dataElement )
-            && value.equals( dv.value );
+    /* Implementation of abstract methods */
+
+    @Override
+    public void writeSubm( SmsSubmissionWriter writer, int version )
+        throws SmsCompressionException
+    {
+        if ( version != 1 && version != 2 )
+        {
+            throw new SmsCompressionException( versionError( version ) );
+        }
+        writer.writeId( event );
     }
 
     @Override
-    public int hashCode()
+    public void readSubm( SmsSubmissionReader reader, int version )
+        throws SmsCompressionException
     {
-        return 0;
+        if ( version != 1 && version != 2 )
+        {
+            throw new SmsCompressionException( versionError( version ) );
+        }
+        this.event = reader.readId( MetadataType.EVENT );
+    }
+
+    @Override
+    public int getCurrentVersion()
+    {
+        return 2;
+    }
+
+    @Override
+    public SubmissionType getType()
+    {
+        return SmsConsts.SubmissionType.DELETE;
     }
 }

--- a/src/main/java/org/hisp/dhis/smscompression/models/EnrollmentSmsSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/EnrollmentSmsSubmission.java
@@ -32,88 +32,88 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
-import org.hisp.dhis.smscompression.SMSCompressionException;
-import org.hisp.dhis.smscompression.SMSConsts;
-import org.hisp.dhis.smscompression.SMSConsts.MetadataType;
-import org.hisp.dhis.smscompression.SMSConsts.SMSEnrollmentStatus;
-import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
-import org.hisp.dhis.smscompression.SMSSubmissionReader;
-import org.hisp.dhis.smscompression.SMSSubmissionWriter;
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.SmsConsts;
+import org.hisp.dhis.smscompression.SmsConsts.MetadataType;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEnrollmentStatus;
+import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
+import org.hisp.dhis.smscompression.SmsSubmissionReader;
+import org.hisp.dhis.smscompression.SmsSubmissionWriter;
 
-public class EnrollmentSMSSubmission
+public class EnrollmentSmsSubmission
     extends
-    SMSSubmission
+    SmsSubmission
 {
-    protected UID orgUnit;
+    protected Uid orgUnit;
 
-    protected UID trackerProgram;
+    protected Uid trackerProgram;
 
-    protected UID trackedEntityType;
+    protected Uid trackedEntityType;
 
-    protected UID trackedEntityInstance;
+    protected Uid trackedEntityInstance;
 
-    protected UID enrollment;
+    protected Uid enrollment;
 
     protected Date enrollmentDate;
 
-    protected SMSEnrollmentStatus enrollmentStatus;
+    protected SmsEnrollmentStatus enrollmentStatus;
 
     protected Date incidentDate;
 
     protected GeoPoint coordinates;
 
-    protected List<SMSAttributeValue> values;
+    protected List<SmsAttributeValue> values;
 
-    protected List<SMSEvent> events;
+    protected List<SmsEvent> events;
 
-    public UID getOrgUnit()
+    public Uid getOrgUnit()
     {
         return orgUnit;
     }
 
     public void setOrgUnit( String orgUnit )
     {
-        this.orgUnit = new UID( orgUnit, MetadataType.ORGANISATION_UNIT );
+        this.orgUnit = new Uid( orgUnit, MetadataType.ORGANISATION_UNIT );
     }
 
-    public UID getTrackerProgram()
+    public Uid getTrackerProgram()
     {
         return trackerProgram;
     }
 
     public void setTrackerProgram( String trackerProgram )
     {
-        this.trackerProgram = new UID( trackerProgram, MetadataType.PROGRAM );
+        this.trackerProgram = new Uid( trackerProgram, MetadataType.PROGRAM );
     }
 
-    public UID getTrackedEntityType()
+    public Uid getTrackedEntityType()
     {
         return trackedEntityType;
     }
 
     public void setTrackedEntityType( String trackedEntityType )
     {
-        this.trackedEntityType = new UID( trackedEntityType, MetadataType.TRACKED_ENTITY_TYPE );
+        this.trackedEntityType = new Uid( trackedEntityType, MetadataType.TRACKED_ENTITY_TYPE );
     }
 
-    public UID getTrackedEntityInstance()
+    public Uid getTrackedEntityInstance()
     {
         return trackedEntityInstance;
     }
 
     public void setTrackedEntityInstance( String trackedEntityInstance )
     {
-        this.trackedEntityInstance = new UID( trackedEntityInstance, MetadataType.TRACKED_ENTITY_INSTANCE );
+        this.trackedEntityInstance = new Uid( trackedEntityInstance, MetadataType.TRACKED_ENTITY_INSTANCE );
     }
 
-    public UID getEnrollment()
+    public Uid getEnrollment()
     {
         return enrollment;
     }
 
     public void setEnrollment( String enrollment )
     {
-        this.enrollment = new UID( enrollment, MetadataType.ENROLLMENT );
+        this.enrollment = new Uid( enrollment, MetadataType.ENROLLMENT );
     }
 
     public Date getEnrollmentDate()
@@ -126,12 +126,12 @@ public class EnrollmentSMSSubmission
         this.enrollmentDate = enrollmentDate;
     }
 
-    public SMSEnrollmentStatus getEnrollmentStatus()
+    public SmsEnrollmentStatus getEnrollmentStatus()
     {
         return enrollmentStatus;
     }
 
-    public void setEnrollmentStatus( SMSEnrollmentStatus enrollmentStatus )
+    public void setEnrollmentStatus( SmsEnrollmentStatus enrollmentStatus )
     {
         this.enrollmentStatus = enrollmentStatus;
     }
@@ -156,22 +156,22 @@ public class EnrollmentSMSSubmission
         this.coordinates = coordinates;
     }
 
-    public List<SMSAttributeValue> getValues()
+    public List<SmsAttributeValue> getValues()
     {
         return values;
     }
 
-    public void setValues( List<SMSAttributeValue> values )
+    public void setValues( List<SmsAttributeValue> values )
     {
         this.values = values;
     }
 
-    public List<SMSEvent> getEvents()
+    public List<SmsEvent> getEvents()
     {
         return events;
     }
 
-    public void setEvents( List<SMSEvent> events )
+    public void setEvents( List<SmsEvent> events )
     {
         this.events = events;
     }
@@ -183,7 +183,7 @@ public class EnrollmentSMSSubmission
         {
             return false;
         }
-        EnrollmentSMSSubmission subm = (EnrollmentSMSSubmission) o;
+        EnrollmentSmsSubmission subm = (EnrollmentSmsSubmission) o;
 
         return Objects.equals( orgUnit, subm.orgUnit ) && Objects.equals( trackerProgram, subm.trackerProgram )
             && Objects.equals( trackedEntityType, subm.trackedEntityType )
@@ -195,8 +195,8 @@ public class EnrollmentSMSSubmission
     }
 
     @Override
-    public void writeSubm( SMSSubmissionWriter writer, int version )
-        throws SMSCompressionException
+    public void writeSubm( SmsSubmissionWriter writer, int version )
+        throws SmsCompressionException
     {
         switch ( version )
         {
@@ -207,30 +207,30 @@ public class EnrollmentSMSSubmission
             writeSubmV2( writer, version );
             break;
         default:
-            throw new SMSCompressionException( versionError( version ) );
+            throw new SmsCompressionException( versionError( version ) );
         }
     }
 
-    private void writeSubmV1( SMSSubmissionWriter writer, int version )
-        throws SMSCompressionException
+    private void writeSubmV1( SmsSubmissionWriter writer, int version )
+        throws SmsCompressionException
     {
-        writer.writeID( orgUnit );
-        writer.writeID( trackerProgram );
-        writer.writeID( trackedEntityType );
-        writer.writeID( trackedEntityInstance );
-        writer.writeID( enrollment );
+        writer.writeId( orgUnit );
+        writer.writeId( trackerProgram );
+        writer.writeId( trackedEntityType );
+        writer.writeId( trackedEntityInstance );
+        writer.writeId( enrollment );
         writer.writeNonNullableDate( enrollmentDate );
         writer.writeAttributeValues( values );
     }
 
-    private void writeSubmV2( SMSSubmissionWriter writer, int version )
-        throws SMSCompressionException
+    private void writeSubmV2( SmsSubmissionWriter writer, int version )
+        throws SmsCompressionException
     {
-        writer.writeID( orgUnit );
-        writer.writeID( trackerProgram );
-        writer.writeID( trackedEntityType );
-        writer.writeID( trackedEntityInstance );
-        writer.writeID( enrollment );
+        writer.writeId( orgUnit );
+        writer.writeId( trackerProgram );
+        writer.writeId( trackedEntityType );
+        writer.writeId( trackedEntityInstance );
+        writer.writeId( enrollment );
         writer.writeDate( enrollmentDate );
         writer.writeEnrollmentStatus( enrollmentStatus );
         writer.writeDate( incidentDate );
@@ -245,8 +245,8 @@ public class EnrollmentSMSSubmission
     }
 
     @Override
-    public void readSubm( SMSSubmissionReader reader, int version )
-        throws SMSCompressionException
+    public void readSubm( SmsSubmissionReader reader, int version )
+        throws SmsCompressionException
     {
         switch ( version )
         {
@@ -257,31 +257,31 @@ public class EnrollmentSMSSubmission
             readSubmV2( reader, version );
             break;
         default:
-            throw new SMSCompressionException( versionError( version ) );
+            throw new SmsCompressionException( versionError( version ) );
         }
     }
 
-    public void readSubmV1( SMSSubmissionReader reader, int version )
-        throws SMSCompressionException
+    public void readSubmV1( SmsSubmissionReader reader, int version )
+        throws SmsCompressionException
     {
-        this.orgUnit = reader.readID( MetadataType.ORGANISATION_UNIT );
-        this.trackerProgram = reader.readID( MetadataType.PROGRAM );
-        this.trackedEntityType = reader.readID( MetadataType.TRACKED_ENTITY_TYPE );
-        this.trackedEntityInstance = reader.readID( MetadataType.TRACKED_ENTITY_INSTANCE );
-        this.enrollment = reader.readID( MetadataType.ENROLLMENT );
+        this.orgUnit = reader.readId( MetadataType.ORGANISATION_UNIT );
+        this.trackerProgram = reader.readId( MetadataType.PROGRAM );
+        this.trackedEntityType = reader.readId( MetadataType.TRACKED_ENTITY_TYPE );
+        this.trackedEntityInstance = reader.readId( MetadataType.TRACKED_ENTITY_INSTANCE );
+        this.enrollment = reader.readId( MetadataType.ENROLLMENT );
         this.enrollmentDate = reader.readNonNullableDate();
         this.values = reader.readAttributeValues();
         this.events = null;
     }
 
-    public void readSubmV2( SMSSubmissionReader reader, int version )
-        throws SMSCompressionException
+    public void readSubmV2( SmsSubmissionReader reader, int version )
+        throws SmsCompressionException
     {
-        this.orgUnit = reader.readID( MetadataType.ORGANISATION_UNIT );
-        this.trackerProgram = reader.readID( MetadataType.PROGRAM );
-        this.trackedEntityType = reader.readID( MetadataType.TRACKED_ENTITY_TYPE );
-        this.trackedEntityInstance = reader.readID( MetadataType.TRACKED_ENTITY_INSTANCE );
-        this.enrollment = reader.readID( MetadataType.ENROLLMENT );
+        this.orgUnit = reader.readId( MetadataType.ORGANISATION_UNIT );
+        this.trackerProgram = reader.readId( MetadataType.PROGRAM );
+        this.trackedEntityType = reader.readId( MetadataType.TRACKED_ENTITY_TYPE );
+        this.trackedEntityInstance = reader.readId( MetadataType.TRACKED_ENTITY_INSTANCE );
+        this.enrollment = reader.readId( MetadataType.ENROLLMENT );
         this.enrollmentDate = reader.readDate();
         this.enrollmentStatus = reader.readEnrollmentStatus();
         this.incidentDate = reader.readDate();
@@ -300,7 +300,7 @@ public class EnrollmentSMSSubmission
     @Override
     public SubmissionType getType()
     {
-        return SMSConsts.SubmissionType.ENROLLMENT;
+        return SmsConsts.SubmissionType.ENROLLMENT;
     }
 
 }

--- a/src/main/java/org/hisp/dhis/smscompression/models/RelationshipSmsSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/RelationshipSmsSubmission.java
@@ -30,65 +30,65 @@ import java.util.Objects;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.smscompression.SMSCompressionException;
-import org.hisp.dhis.smscompression.SMSConsts;
-import org.hisp.dhis.smscompression.SMSConsts.MetadataType;
-import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
-import org.hisp.dhis.smscompression.SMSSubmissionReader;
-import org.hisp.dhis.smscompression.SMSSubmissionWriter;
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.SmsConsts;
+import org.hisp.dhis.smscompression.SmsConsts.MetadataType;
+import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
+import org.hisp.dhis.smscompression.SmsSubmissionReader;
+import org.hisp.dhis.smscompression.SmsSubmissionWriter;
 
-public class RelationshipSMSSubmission
+public class RelationshipSmsSubmission
     extends
-    SMSSubmission
+    SmsSubmission
 {
-    protected UID relationshipType;
+    protected Uid relationshipType;
 
-    protected UID relationship;
+    protected Uid relationship;
 
-    protected UID from;
+    protected Uid from;
 
-    protected UID to;
+    protected Uid to;
 
     /* Getters and Setters */
 
-    public UID getRelationshipType()
+    public Uid getRelationshipType()
     {
         return relationshipType;
     }
 
     public void setRelationshipType( String relationshipType )
     {
-        this.relationshipType = new UID( relationshipType, MetadataType.RELATIONSHIP_TYPE );
+        this.relationshipType = new Uid( relationshipType, MetadataType.RELATIONSHIP_TYPE );
     }
 
-    public UID getRelationship()
+    public Uid getRelationship()
     {
         return relationship;
     }
 
     public void setRelationship( String relationship )
     {
-        this.relationship = new UID( relationship, MetadataType.RELATIONSHIP );
+        this.relationship = new Uid( relationship, MetadataType.RELATIONSHIP );
     }
 
-    public UID getFrom()
+    public Uid getFrom()
     {
         return from;
     }
 
     public void setFrom( String from )
     {
-        this.from = new UID( from, null );
+        this.from = new Uid( from, null );
     }
 
-    public UID getTo()
+    public Uid getTo()
     {
         return to;
     }
 
     public void setTo( String to )
     {
-        this.to = new UID( to, null );
+        this.to = new Uid( to, null );
     }
 
     @Override
@@ -98,7 +98,7 @@ public class RelationshipSMSSubmission
         {
             return false;
         }
-        RelationshipSMSSubmission subm = (RelationshipSMSSubmission) o;
+        RelationshipSmsSubmission subm = (RelationshipSmsSubmission) o;
 
         return Objects.equals( relationshipType, subm.relationshipType )
             && Objects.equals( relationship, subm.relationship ) && Objects.equals( from, subm.from )
@@ -108,31 +108,31 @@ public class RelationshipSMSSubmission
     /* Implementation of abstract methods */
 
     @Override
-    public void writeSubm( SMSSubmissionWriter writer, int version )
-        throws SMSCompressionException
+    public void writeSubm( SmsSubmissionWriter writer, int version )
+        throws SmsCompressionException
     {
         if ( version != 1 && version != 2 )
         {
-            throw new SMSCompressionException( versionError( version ) );
+            throw new SmsCompressionException( versionError( version ) );
         }
-        writer.writeID( relationshipType );
-        writer.writeID( relationship );
-        writer.writeNewID( from.getUID() );
-        writer.writeNewID( to.getUID() );
+        writer.writeId( relationshipType );
+        writer.writeId( relationship );
+        writer.writeNewId( from.getUid() );
+        writer.writeNewId( to.getUid() );
     }
 
     @Override
-    public void readSubm( SMSSubmissionReader reader, int version )
-        throws SMSCompressionException
+    public void readSubm( SmsSubmissionReader reader, int version )
+        throws SmsCompressionException
     {
         if ( version != 1 && version != 2 )
         {
-            throw new SMSCompressionException( versionError( version ) );
+            throw new SmsCompressionException( versionError( version ) );
         }
-        this.relationshipType = reader.readID( MetadataType.RELATIONSHIP_TYPE );
-        this.relationship = reader.readID( MetadataType.RELATIONSHIP );
-        this.from = new UID( reader.readNewID(), null );
-        this.to = new UID( reader.readNewID(), null );
+        this.relationshipType = reader.readId( MetadataType.RELATIONSHIP_TYPE );
+        this.relationship = reader.readId( MetadataType.RELATIONSHIP );
+        this.from = new Uid( reader.readNewId(), null );
+        this.to = new Uid( reader.readNewId(), null );
     }
 
     @Override
@@ -144,6 +144,6 @@ public class RelationshipSMSSubmission
     @Override
     public SubmissionType getType()
     {
-        return SMSConsts.SubmissionType.RELATIONSHIP;
+        return SmsConsts.SubmissionType.RELATIONSHIP;
     }
 }

--- a/src/main/java/org/hisp/dhis/smscompression/models/SimpleEventSmsSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/SimpleEventSmsSubmission.java
@@ -32,29 +32,27 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
-import org.hisp.dhis.smscompression.SMSCompressionException;
-import org.hisp.dhis.smscompression.SMSConsts;
-import org.hisp.dhis.smscompression.SMSConsts.MetadataType;
-import org.hisp.dhis.smscompression.SMSConsts.SMSEventStatus;
-import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
-import org.hisp.dhis.smscompression.SMSSubmissionReader;
-import org.hisp.dhis.smscompression.SMSSubmissionWriter;
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.SmsConsts;
+import org.hisp.dhis.smscompression.SmsConsts.MetadataType;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEventStatus;
+import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
+import org.hisp.dhis.smscompression.SmsSubmissionReader;
+import org.hisp.dhis.smscompression.SmsSubmissionWriter;
 
-public class TrackerEventSMSSubmission
+public class SimpleEventSmsSubmission
     extends
-    SMSSubmission
+    SmsSubmission
 {
-    protected UID orgUnit;
+    protected Uid orgUnit;
 
-    protected UID programStage;
+    protected Uid eventProgram;
 
-    protected SMSEventStatus eventStatus;
+    protected SmsEventStatus eventStatus;
 
-    protected UID attributeOptionCombo;
+    protected Uid attributeOptionCombo;
 
-    protected UID enrollment;
-
-    protected UID event;
+    protected Uid event;
 
     protected Date eventDate;
 
@@ -62,68 +60,58 @@ public class TrackerEventSMSSubmission
 
     protected GeoPoint coordinates;
 
-    protected List<SMSDataValue> values;
+    protected List<SmsDataValue> values;
 
     /* Getters and Setters */
 
-    public UID getOrgUnit()
+    public Uid getOrgUnit()
     {
         return orgUnit;
     }
 
     public void setOrgUnit( String orgUnit )
     {
-        this.orgUnit = new UID( orgUnit, MetadataType.ORGANISATION_UNIT );
+        this.orgUnit = new Uid( orgUnit, MetadataType.ORGANISATION_UNIT );
     }
 
-    public UID getProgramStage()
+    public Uid getEventProgram()
     {
-        return programStage;
+        return eventProgram;
     }
 
-    public void setProgramStage( String programStage )
+    public void setEventProgram( String eventProgram )
     {
-        this.programStage = new UID( programStage, MetadataType.PROGRAM_STAGE );
+        this.eventProgram = new Uid( eventProgram, MetadataType.PROGRAM );
     }
 
-    public SMSEventStatus getEventStatus()
+    public SmsEventStatus getEventStatus()
     {
         return eventStatus;
     }
 
-    public void setEventStatus( SMSEventStatus eventStatus )
+    public void setEventStatus( SmsEventStatus eventStatus )
     {
         this.eventStatus = eventStatus;
     }
 
-    public UID getAttributeOptionCombo()
+    public Uid getAttributeOptionCombo()
     {
         return attributeOptionCombo;
     }
 
     public void setAttributeOptionCombo( String attributeOptionCombo )
     {
-        this.attributeOptionCombo = new UID( attributeOptionCombo, MetadataType.CATEGORY_OPTION_COMBO );
+        this.attributeOptionCombo = new Uid( attributeOptionCombo, MetadataType.CATEGORY_OPTION_COMBO );
     }
 
-    public UID getEnrollment()
-    {
-        return enrollment;
-    }
-
-    public void setEnrollment( String enrollment )
-    {
-        this.enrollment = new UID( enrollment, MetadataType.ENROLLMENT );
-    }
-
-    public UID getEvent()
+    public Uid getEvent()
     {
         return event;
     }
 
     public void setEvent( String event )
     {
-        this.event = new UID( event, MetadataType.EVENT );
+        this.event = new Uid( event, MetadataType.EVENT );
     }
 
     public Date getEventDate()
@@ -156,12 +144,12 @@ public class TrackerEventSMSSubmission
         this.coordinates = coordinates;
     }
 
-    public List<SMSDataValue> getValues()
+    public List<SmsDataValue> getValues()
     {
         return values;
     }
 
-    public void setValues( List<SMSDataValue> values )
+    public void setValues( List<SmsDataValue> values )
     {
         this.values = values;
     }
@@ -173,21 +161,20 @@ public class TrackerEventSMSSubmission
         {
             return false;
         }
-        TrackerEventSMSSubmission subm = (TrackerEventSMSSubmission) o;
+        SimpleEventSmsSubmission subm = (SimpleEventSmsSubmission) o;
 
-        return Objects.equals( orgUnit, subm.orgUnit ) && Objects.equals( programStage, subm.programStage )
+        return Objects.equals( orgUnit, subm.orgUnit ) && Objects.equals( eventProgram, subm.eventProgram )
             && Objects.equals( eventStatus, subm.eventStatus )
-            && Objects.equals( attributeOptionCombo, subm.attributeOptionCombo ) && enrollment.equals( subm.enrollment )
-            && Objects.equals( event, subm.event ) && Objects.equals( eventDate, subm.eventDate )
-            && Objects.equals( dueDate, subm.dueDate ) && Objects.equals( coordinates, subm.coordinates )
-            && Objects.equals( values, subm.values );
+            && Objects.equals( attributeOptionCombo, subm.attributeOptionCombo ) && Objects.equals( event, subm.event )
+            && Objects.equals( eventDate, subm.eventDate ) && Objects.equals( dueDate, subm.dueDate )
+            && Objects.equals( coordinates, subm.coordinates ) && Objects.equals( values, subm.values );
     }
 
     /* Implementation of abstract methods */
 
     @Override
-    public void writeSubm( SMSSubmissionWriter writer, int version )
-        throws SMSCompressionException
+    public void writeSubm( SmsSubmissionWriter writer, int version )
+        throws SmsCompressionException
     {
         switch ( version )
         {
@@ -198,32 +185,30 @@ public class TrackerEventSMSSubmission
             writeSubmV2( writer );
             break;
         default:
-            throw new SMSCompressionException( versionError( version ) );
+            throw new SmsCompressionException( versionError( version ) );
         }
     }
 
-    private void writeSubmV1( SMSSubmissionWriter writer )
-        throws SMSCompressionException
+    private void writeSubmV1( SmsSubmissionWriter writer )
+        throws SmsCompressionException
     {
-        writer.writeID( orgUnit );
-        writer.writeID( programStage );
+        writer.writeId( orgUnit );
+        writer.writeId( eventProgram );
         writer.writeEventStatus( eventStatus );
-        writer.writeID( attributeOptionCombo );
-        writer.writeID( enrollment );
-        writer.writeID( event );
+        writer.writeId( attributeOptionCombo );
+        writer.writeId( event );
         writer.writeNonNullableDate( eventDate );
         writer.writeDataValues( values );
     }
 
-    private void writeSubmV2( SMSSubmissionWriter writer )
-        throws SMSCompressionException
+    private void writeSubmV2( SmsSubmissionWriter writer )
+        throws SmsCompressionException
     {
-        writer.writeID( orgUnit );
-        writer.writeID( programStage );
+        writer.writeId( orgUnit );
+        writer.writeId( eventProgram );
         writer.writeEventStatus( eventStatus );
-        writer.writeID( attributeOptionCombo );
-        writer.writeID( enrollment );
-        writer.writeID( event );
+        writer.writeId( attributeOptionCombo );
+        writer.writeId( event );
         writer.writeDate( eventDate );
         writer.writeDate( dueDate );
         writer.writeGeoPoint( coordinates );
@@ -236,8 +221,8 @@ public class TrackerEventSMSSubmission
     }
 
     @Override
-    public void readSubm( SMSSubmissionReader reader, int version )
-        throws SMSCompressionException
+    public void readSubm( SmsSubmissionReader reader, int version )
+        throws SmsCompressionException
     {
         switch ( version )
         {
@@ -248,32 +233,30 @@ public class TrackerEventSMSSubmission
             readSubmV2( reader );
             break;
         default:
-            throw new SMSCompressionException( versionError( version ) );
+            throw new SmsCompressionException( versionError( version ) );
         }
     }
 
-    private void readSubmV1( SMSSubmissionReader reader )
-        throws SMSCompressionException
+    private void readSubmV1( SmsSubmissionReader reader )
+        throws SmsCompressionException
     {
-        this.orgUnit = reader.readID( MetadataType.ORGANISATION_UNIT );
-        this.programStage = reader.readID( MetadataType.PROGRAM_STAGE );
+        this.orgUnit = reader.readId( MetadataType.ORGANISATION_UNIT );
+        this.eventProgram = reader.readId( MetadataType.PROGRAM );
         this.eventStatus = reader.readEventStatus();
-        this.attributeOptionCombo = reader.readID( MetadataType.CATEGORY_OPTION_COMBO );
-        this.enrollment = reader.readID( MetadataType.ENROLLMENT );
-        this.event = reader.readID( MetadataType.EVENT );
+        this.attributeOptionCombo = reader.readId( MetadataType.CATEGORY_OPTION_COMBO );
+        this.event = reader.readId( MetadataType.EVENT );
         this.eventDate = reader.readNonNullableDate();
         this.values = reader.readDataValues();
     }
 
-    private void readSubmV2( SMSSubmissionReader reader )
-        throws SMSCompressionException
+    private void readSubmV2( SmsSubmissionReader reader )
+        throws SmsCompressionException
     {
-        this.orgUnit = reader.readID( MetadataType.ORGANISATION_UNIT );
-        this.programStage = reader.readID( MetadataType.PROGRAM_STAGE );
+        this.orgUnit = reader.readId( MetadataType.ORGANISATION_UNIT );
+        this.eventProgram = reader.readId( MetadataType.PROGRAM );
         this.eventStatus = reader.readEventStatus();
-        this.attributeOptionCombo = reader.readID( MetadataType.CATEGORY_OPTION_COMBO );
-        this.enrollment = reader.readID( MetadataType.ENROLLMENT );
-        this.event = reader.readID( MetadataType.EVENT );
+        this.attributeOptionCombo = reader.readId( MetadataType.CATEGORY_OPTION_COMBO );
+        this.event = reader.readId( MetadataType.EVENT );
         this.eventDate = reader.readDate();
         this.dueDate = reader.readDate();
         this.coordinates = reader.readGeoPoint();
@@ -290,6 +273,6 @@ public class TrackerEventSMSSubmission
     @Override
     public SubmissionType getType()
     {
-        return SMSConsts.SubmissionType.TRACKER_EVENT;
+        return SmsConsts.SubmissionType.SIMPLE_EVENT;
     }
 }

--- a/src/main/java/org/hisp/dhis/smscompression/models/SmsAttributeValue.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/SmsAttributeValue.java
@@ -1,6 +1,7 @@
 package org.hisp.dhis.smscompression.models;
 
-import java.util.Objects;
+import org.hisp.dhis.smscompression.SmsConsts.MetadataType;
+import org.hisp.dhis.smscompression.SmsConsts.ValueType;
 
 /*
  * Copyright (c) 2004-2019, University of Oslo
@@ -30,75 +31,65 @@ import java.util.Objects;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.smscompression.SMSCompressionException;
-import org.hisp.dhis.smscompression.SMSConsts;
-import org.hisp.dhis.smscompression.SMSConsts.MetadataType;
-import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
-import org.hisp.dhis.smscompression.SMSSubmissionReader;
-import org.hisp.dhis.smscompression.SMSSubmissionWriter;
-
-public class DeleteSMSSubmission
-    extends
-    SMSSubmission
+public class SmsAttributeValue
 {
-    protected UID event;
+    protected Uid attribute;
 
-    /* Getters and Setters */
+    protected String value;
 
-    public UID getEvent()
+    protected SmsValue<?> smsValue;
+
+    protected ValueType type;
+
+    public SmsAttributeValue( String attribute, String value )
     {
-        return event;
+        this.attribute = new Uid( attribute, MetadataType.TRACKED_ENTITY_ATTRIBUTE );
+        this.value = value;
+        this.smsValue = SmsValue.asSmsValue( value );
     }
 
-    public void setEvent( String event )
+    public SmsAttributeValue( Uid attribute, SmsValue<?> smsValue )
     {
-        this.event = new UID( event, MetadataType.EVENT );
+        this.attribute = attribute;
+        this.smsValue = smsValue;
+        // TODO: We probably need better handling than just toString() here
+        this.value = smsValue.getValue().toString();
+    }
+
+    public Uid getAttribute()
+    {
+        return this.attribute;
+    }
+
+    public String getValue()
+    {
+        return this.value;
+    }
+
+    public SmsValue<?> getSmsValue()
+    {
+        return this.smsValue;
     }
 
     @Override
     public boolean equals( Object o )
     {
-        if ( !super.equals( o ) )
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
         {
             return false;
         }
-        DeleteSMSSubmission subm = (DeleteSMSSubmission) o;
-        return Objects.equals( event, subm.event );
-    }
+        SmsAttributeValue dv = (SmsAttributeValue) o;
 
-    /* Implementation of abstract methods */
-
-    @Override
-    public void writeSubm( SMSSubmissionWriter writer, int version )
-        throws SMSCompressionException
-    {
-        if ( version != 1 && version != 2 )
-        {
-            throw new SMSCompressionException( versionError( version ) );
-        }
-        writer.writeID( event );
+        return attribute.equals( dv.attribute ) && value.equals( dv.value );
     }
 
     @Override
-    public void readSubm( SMSSubmissionReader reader, int version )
-        throws SMSCompressionException
+    public int hashCode()
     {
-        if ( version != 1 && version != 2 )
-        {
-            throw new SMSCompressionException( versionError( version ) );
-        }
-        this.event = reader.readID( MetadataType.EVENT );
-    }
-
-    @Override
-    public int getCurrentVersion()
-    {
-        return 2;
-    }
-
-    @Override
-    public SubmissionType getType()
-    {
-        return SMSConsts.SubmissionType.DELETE;
+        return 0;
     }
 }

--- a/src/main/java/org/hisp/dhis/smscompression/models/SmsDataValue.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/SmsDataValue.java
@@ -1,7 +1,6 @@
 package org.hisp.dhis.smscompression.models;
 
-import org.hisp.dhis.smscompression.SMSConsts.MetadataType;
-import org.hisp.dhis.smscompression.SMSConsts.ValueType;
+import org.hisp.dhis.smscompression.SmsConsts.MetadataType;
 
 /*
  * Copyright (c) 2004-2019, University of Oslo
@@ -31,44 +30,51 @@ import org.hisp.dhis.smscompression.SMSConsts.ValueType;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-public class SMSAttributeValue
+public class SmsDataValue
 {
-    protected UID attribute;
+    protected Uid categoryOptionCombo;
+
+    protected Uid dataElement;
 
     protected String value;
 
-    protected SMSValue<?> smsValue;
+    protected SmsValue<?> smsValue;
 
-    protected ValueType type;
-
-    public SMSAttributeValue( String attribute, String value )
+    public SmsDataValue( String categoryOptionCombo, String dataElement, String value )
     {
-        this.attribute = new UID( attribute, MetadataType.TRACKED_ENTITY_ATTRIBUTE );
+        this.categoryOptionCombo = new Uid( categoryOptionCombo, MetadataType.CATEGORY_OPTION_COMBO );
+        this.dataElement = new Uid( dataElement, MetadataType.DATA_ELEMENT );
         this.value = value;
-        this.smsValue = SMSValue.asSMSValue( value );
+        this.smsValue = SmsValue.asSmsValue( value );
     }
 
-    public SMSAttributeValue( UID attribute, SMSValue<?> smsValue )
+    public SmsDataValue( Uid categoryOptionCombo, Uid dataElement, SmsValue<?> smsValue )
     {
-        this.attribute = attribute;
+        this.categoryOptionCombo = categoryOptionCombo;
+        this.dataElement = dataElement;
         this.smsValue = smsValue;
         // TODO: We probably need better handling than just toString() here
         this.value = smsValue.getValue().toString();
     }
 
-    public UID getAttribute()
+    public Uid getCategoryOptionCombo()
     {
-        return this.attribute;
+        return categoryOptionCombo;
+    }
+
+    public Uid getDataElement()
+    {
+        return dataElement;
     }
 
     public String getValue()
     {
-        return this.value;
+        return value;
     }
 
-    public SMSValue<?> getSMSValue()
+    public SmsValue<?> getSmsValue()
     {
-        return this.smsValue;
+        return smsValue;
     }
 
     @Override
@@ -82,9 +88,10 @@ public class SMSAttributeValue
         {
             return false;
         }
-        SMSAttributeValue dv = (SMSAttributeValue) o;
+        SmsDataValue dv = (SmsDataValue) o;
 
-        return attribute.equals( dv.attribute ) && value.equals( dv.value );
+        return categoryOptionCombo.equals( dv.categoryOptionCombo ) && dataElement.equals( dv.dataElement )
+            && value.equals( dv.value );
     }
 
     @Override

--- a/src/main/java/org/hisp/dhis/smscompression/models/SmsEvent.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/SmsEvent.java
@@ -32,23 +32,23 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
-import org.hisp.dhis.smscompression.SMSCompressionException;
-import org.hisp.dhis.smscompression.SMSConsts.MetadataType;
-import org.hisp.dhis.smscompression.SMSConsts.SMSEventStatus;
-import org.hisp.dhis.smscompression.SMSSubmissionReader;
-import org.hisp.dhis.smscompression.SMSSubmissionWriter;
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.SmsConsts.MetadataType;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEventStatus;
+import org.hisp.dhis.smscompression.SmsSubmissionReader;
+import org.hisp.dhis.smscompression.SmsSubmissionWriter;
 
-public class SMSEvent
+public class SmsEvent
 {
-    protected UID orgUnit;
+    protected Uid orgUnit;
 
-    protected UID programStage;
+    protected Uid programStage;
 
-    protected SMSEventStatus eventStatus;
+    protected SmsEventStatus eventStatus;
 
-    protected UID attributeOptionCombo;
+    protected Uid attributeOptionCombo;
 
-    protected UID event;
+    protected Uid event;
 
     protected Date eventDate;
 
@@ -56,56 +56,56 @@ public class SMSEvent
 
     protected GeoPoint coordinates;
 
-    protected List<SMSDataValue> values;
+    protected List<SmsDataValue> values;
 
-    public UID getOrgUnit()
+    public Uid getOrgUnit()
     {
         return orgUnit;
     }
 
     public void setOrgUnit( String orgUnit )
     {
-        this.orgUnit = new UID( orgUnit, MetadataType.ORGANISATION_UNIT );
+        this.orgUnit = new Uid( orgUnit, MetadataType.ORGANISATION_UNIT );
     }
 
-    public UID getProgramStage()
+    public Uid getProgramStage()
     {
         return programStage;
     }
 
     public void setProgramStage( String programStage )
     {
-        this.programStage = new UID( programStage, MetadataType.PROGRAM_STAGE );
+        this.programStage = new Uid( programStage, MetadataType.PROGRAM_STAGE );
     }
 
-    public SMSEventStatus getEventStatus()
+    public SmsEventStatus getEventStatus()
     {
         return eventStatus;
     }
 
-    public void setEventStatus( SMSEventStatus eventStatus )
+    public void setEventStatus( SmsEventStatus eventStatus )
     {
         this.eventStatus = eventStatus;
     }
 
-    public UID getAttributeOptionCombo()
+    public Uid getAttributeOptionCombo()
     {
         return attributeOptionCombo;
     }
 
     public void setAttributeOptionCombo( String attributeOptionCombo )
     {
-        this.attributeOptionCombo = new UID( attributeOptionCombo, MetadataType.CATEGORY_OPTION_COMBO );
+        this.attributeOptionCombo = new Uid( attributeOptionCombo, MetadataType.CATEGORY_OPTION_COMBO );
     }
 
-    public UID getEvent()
+    public Uid getEvent()
     {
         return event;
     }
 
     public void setEvent( String event )
     {
-        this.event = new UID( event, MetadataType.EVENT );
+        this.event = new Uid( event, MetadataType.EVENT );
     }
 
     public Date getEventDate()
@@ -138,12 +138,12 @@ public class SMSEvent
         this.coordinates = coordinates;
     }
 
-    public List<SMSDataValue> getValues()
+    public List<SmsDataValue> getValues()
     {
         return values;
     }
 
-    public void setValues( List<SMSDataValue> values )
+    public void setValues( List<SmsDataValue> values )
     {
         this.values = values;
     }
@@ -159,7 +159,7 @@ public class SMSEvent
         {
             return false;
         }
-        SMSEvent e = (SMSEvent) o;
+        SmsEvent e = (SmsEvent) o;
 
         return Objects.equals( orgUnit, e.orgUnit ) && Objects.equals( programStage, e.programStage )
             && Objects.equals( eventStatus, e.eventStatus )
@@ -168,19 +168,19 @@ public class SMSEvent
             && Objects.equals( coordinates, e.coordinates ) && Objects.equals( values, e.values );
     }
 
-    public void writeEvent( SMSSubmissionWriter writer, int version )
-        throws SMSCompressionException
+    public void writeEvent( SmsSubmissionWriter writer, int version )
+        throws SmsCompressionException
     {
         if ( version != 2 )
         {
-            throw new SMSCompressionException( versionError( version ) );
+            throw new SmsCompressionException( versionError( version ) );
         }
 
-        writer.writeID( orgUnit );
-        writer.writeID( programStage );
+        writer.writeId( orgUnit );
+        writer.writeId( programStage );
         writer.writeEventStatus( eventStatus );
-        writer.writeID( attributeOptionCombo );
-        writer.writeID( event );
+        writer.writeId( attributeOptionCombo );
+        writer.writeId( event );
         writer.writeDate( eventDate );
         writer.writeDate( dueDate );
         writer.writeGeoPoint( coordinates );
@@ -192,19 +192,19 @@ public class SMSEvent
         }
     }
 
-    public void readEvent( SMSSubmissionReader reader, int version )
-        throws SMSCompressionException
+    public void readEvent( SmsSubmissionReader reader, int version )
+        throws SmsCompressionException
     {
         if ( version != 2 )
         {
-            throw new SMSCompressionException( versionError( version ) );
+            throw new SmsCompressionException( versionError( version ) );
         }
 
-        this.orgUnit = reader.readID( MetadataType.ORGANISATION_UNIT );
-        this.programStage = reader.readID( MetadataType.PROGRAM_STAGE );
+        this.orgUnit = reader.readId( MetadataType.ORGANISATION_UNIT );
+        this.programStage = reader.readId( MetadataType.PROGRAM_STAGE );
         this.eventStatus = reader.readEventStatus();
-        this.attributeOptionCombo = reader.readID( MetadataType.CATEGORY_OPTION_COMBO );
-        this.event = reader.readID( MetadataType.EVENT );
+        this.attributeOptionCombo = reader.readId( MetadataType.CATEGORY_OPTION_COMBO );
+        this.event = reader.readId( MetadataType.EVENT );
         this.eventDate = reader.readDate();
         this.dueDate = reader.readDate();
         this.coordinates = reader.readGeoPoint();

--- a/src/main/java/org/hisp/dhis/smscompression/models/SmsMetadata.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/SmsMetadata.java
@@ -35,11 +35,11 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 
-import org.hisp.dhis.smscompression.SMSCompressionException;
-import org.hisp.dhis.smscompression.SMSConsts.MetadataType;
-import org.hisp.dhis.smscompression.utils.IDUtil;
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.SmsConsts.MetadataType;
+import org.hisp.dhis.smscompression.utils.IdUtil;
 
-public class SMSMetadata
+public class SmsMetadata
 {
     public static final List<MetadataType> ValidHashTypes = Collections
         .unmodifiableList( Arrays.asList( MetadataType.USER, MetadataType.TRACKED_ENTITY_TYPE,
@@ -47,11 +47,11 @@ public class SMSMetadata
             MetadataType.DATA_ELEMENT, MetadataType.CATEGORY_OPTION_COMBO, MetadataType.DATASET,
             MetadataType.PROGRAM_STAGE, MetadataType.RELATIONSHIP_TYPE ) );
 
-    public static class ID
+    public static class Id
     {
         String id;
 
-        public ID( String id )
+        public Id( String id )
         {
             this.id = id;
         }
@@ -59,46 +59,46 @@ public class SMSMetadata
 
     public Date lastSyncDate;
 
-    public List<ID> users;
+    public List<Id> users;
 
-    public List<ID> trackedEntityTypes;
+    public List<Id> trackedEntityTypes;
 
-    public List<ID> trackedEntityAttributes;
+    public List<Id> trackedEntityAttributes;
 
-    public List<ID> programs;
+    public List<Id> programs;
 
-    public List<ID> organisationUnits;
+    public List<Id> organisationUnits;
 
-    public List<ID> dataElements;
+    public List<Id> dataElements;
 
-    public List<ID> categoryOptionCombos;
+    public List<Id> categoryOptionCombos;
 
-    public List<ID> dataSets;
+    public List<Id> dataSets;
 
-    public List<ID> programStages;
+    public List<Id> programStages;
 
-    public List<ID> relationshipTypes;
+    public List<Id> relationshipTypes;
 
     public void validate()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         for ( MetadataType type : ValidHashTypes )
         {
-            checkIDList( getType( type ), type );
+            checkIdList( getType( type ), type );
         }
     }
 
-    public static boolean checkIDList( List<String> ids, MetadataType type )
-        throws SMSCompressionException
+    public static boolean checkIdList( List<String> ids, MetadataType type )
+        throws SmsCompressionException
     {
         String typeMsg = "Metadata error[" + type + "]:";
         HashSet<String> set = new HashSet<>();
         for ( String id : ids )
         {
             if ( !set.add( id ) )
-                throw new SMSCompressionException( typeMsg + "List of UIDs in Metadata contains duplicate: " + id );
-            if ( !IDUtil.validID( id ) )
-                throw new SMSCompressionException( typeMsg + "Invalid format UID found in Metadata UID List: " + id );
+                throw new SmsCompressionException( typeMsg + "List of UIDs in Metadata contains duplicate: " + id );
+            if ( !IdUtil.validId( id ) )
+                throw new SmsCompressionException( typeMsg + "Invalid format UID found in Metadata UID List: " + id );
         }
 
         return true;
@@ -109,38 +109,38 @@ public class SMSMetadata
         switch ( type )
         {
         case USER:
-            return getIDs( users );
+            return getIds( users );
         case TRACKED_ENTITY_TYPE:
-            return getIDs( trackedEntityTypes );
+            return getIds( trackedEntityTypes );
         case TRACKED_ENTITY_ATTRIBUTE:
-            return getIDs( trackedEntityAttributes );
+            return getIds( trackedEntityAttributes );
         case PROGRAM:
-            return getIDs( programs );
+            return getIds( programs );
         case ORGANISATION_UNIT:
-            return getIDs( organisationUnits );
+            return getIds( organisationUnits );
         case DATA_ELEMENT:
-            return getIDs( dataElements );
+            return getIds( dataElements );
         case CATEGORY_OPTION_COMBO:
-            return getIDs( categoryOptionCombos );
+            return getIds( categoryOptionCombos );
         case DATASET:
-            return getIDs( dataSets );
+            return getIds( dataSets );
         case PROGRAM_STAGE:
-            return getIDs( programStages );
+            return getIds( programStages );
         case RELATIONSHIP_TYPE:
-            return getIDs( relationshipTypes );
+            return getIds( relationshipTypes );
 
         default:
             return null;
         }
     }
 
-    private List<String> getIDs( List<ID> ids )
+    private List<String> getIds( List<Id> ids )
     {
         ArrayList<String> idList = new ArrayList<>();
 
         if ( ids != null )
         {
-            for ( ID id : ids )
+            for ( Id id : ids )
             {
                 idList.add( id.id );
             }

--- a/src/main/java/org/hisp/dhis/smscompression/models/SmsSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/SmsSubmission.java
@@ -30,17 +30,17 @@ import java.util.Date;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.smscompression.SMSCompressionException;
-import org.hisp.dhis.smscompression.SMSConsts.MetadataType;
-import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
-import org.hisp.dhis.smscompression.SMSSubmissionReader;
-import org.hisp.dhis.smscompression.SMSSubmissionWriter;
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.SmsConsts.MetadataType;
+import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
+import org.hisp.dhis.smscompression.SmsSubmissionReader;
+import org.hisp.dhis.smscompression.SmsSubmissionWriter;
 
-public abstract class SMSSubmission
+public abstract class SmsSubmission
 {
-    protected SMSSubmissionHeader header;
+    protected SmsSubmissionHeader header;
 
-    protected UID userID;
+    protected Uid userId;
 
     public abstract int getCurrentVersion();
 
@@ -48,18 +48,18 @@ public abstract class SMSSubmission
 
     // Note: When handling versioning, create a new method to handle
     // each version, rather than handling all formats in this method alone
-    public abstract void writeSubm( SMSSubmissionWriter writer, int version )
-        throws SMSCompressionException;
+    public abstract void writeSubm( SmsSubmissionWriter writer, int version )
+        throws SmsCompressionException;
 
-    public abstract void readSubm( SMSSubmissionReader reader, int version )
-        throws SMSCompressionException;
+    public abstract void readSubm( SmsSubmissionReader reader, int version )
+        throws SmsCompressionException;
 
-    public SMSSubmission()
+    public SmsSubmission()
     {
-        this.header = new SMSSubmissionHeader();
+        this.header = new SmsSubmissionHeader();
         header.setType( this.getType() );
         // Initialise the submission ID so we know if it's been set correctly
-        header.setSubmissionID( -1 );
+        header.setSubmissionId( -1 );
     }
 
     @Override
@@ -73,38 +73,38 @@ public abstract class SMSSubmission
         {
             return false;
         }
-        SMSSubmission subm = (SMSSubmission) o;
-        return userID.equals( subm.userID ) && header.equals( subm.header );
+        SmsSubmission subm = (SmsSubmission) o;
+        return userId.equals( subm.userId ) && header.equals( subm.header );
     }
 
-    public void setSubmissionID( int submissionID )
+    public void setSubmissionId( int submissionId )
     {
-        header.setSubmissionID( submissionID );
+        header.setSubmissionId( submissionId );
     }
 
-    public UID getUserID()
+    public Uid getUserId()
     {
-        return userID;
+        return userId;
     }
 
-    public void setUserID( String userID )
+    public void setUserId( String userId )
     {
-        this.userID = new UID( userID, MetadataType.USER );
+        this.userId = new Uid( userId, MetadataType.USER );
     }
 
     public void validateSubmission()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         header.validateHeaer();
-        if ( userID.getUID().isEmpty() )
+        if ( userId.getUid().isEmpty() )
         {
-            throw new SMSCompressionException( "Ensure the UserID is set in the submission" );
+            throw new SmsCompressionException( "Ensure the UserID is set in the submission" );
         }
         // TODO: We should run validations on each submission here
     }
 
-    public void write( SMSMetadata meta, SMSSubmissionWriter writer, int version )
-        throws SMSCompressionException
+    public void write( SmsMetadata meta, SmsSubmissionWriter writer, int version )
+        throws SmsCompressionException
     {
         // Ensure we set the lastSyncDate in the subm header
         Date lastSyncDate = meta != null && meta.lastSyncDate != null ? meta.lastSyncDate : new Date( 0 );
@@ -113,15 +113,15 @@ public abstract class SMSSubmission
         validateSubmission();
         header.setVersion( version );
         header.writeHeader( writer );
-        writer.writeID( userID );
+        writer.writeId( userId );
         writeSubm( writer, version );
     }
 
-    public void read( SMSSubmissionReader reader, SMSSubmissionHeader header )
-        throws SMSCompressionException
+    public void read( SmsSubmissionReader reader, SmsSubmissionHeader header )
+        throws SmsCompressionException
     {
         this.header = header;
-        this.userID = reader.readID( MetadataType.USER );
+        this.userId = reader.readId( MetadataType.USER );
         readSubm( reader, this.header.getVersion() );
     }
 

--- a/src/main/java/org/hisp/dhis/smscompression/models/SmsSubmissionHeader.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/SmsSubmissionHeader.java
@@ -30,12 +30,12 @@ package org.hisp.dhis.smscompression.models;
 
 import java.util.Date;
 
-import org.hisp.dhis.smscompression.SMSCompressionException;
-import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
-import org.hisp.dhis.smscompression.SMSSubmissionReader;
-import org.hisp.dhis.smscompression.SMSSubmissionWriter;
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
+import org.hisp.dhis.smscompression.SmsSubmissionReader;
+import org.hisp.dhis.smscompression.SmsSubmissionWriter;
 
-public class SMSSubmissionHeader
+public class SmsSubmissionHeader
 {
     protected SubmissionType type;
 
@@ -43,16 +43,16 @@ public class SMSSubmissionHeader
 
     protected Date lastSyncDate;
 
-    protected int submissionID;
+    protected int submissionId;
 
-    public int getSubmissionID()
+    public int getSubmissionId()
     {
-        return submissionID;
+        return submissionId;
     }
 
-    public void setSubmissionID( int submissionID )
+    public void setSubmissionId( int submissionId )
     {
-        this.submissionID = submissionID;
+        this.submissionId = submissionId;
     }
 
     public SubmissionType getType()
@@ -96,36 +96,36 @@ public class SMSSubmissionHeader
         {
             return false;
         }
-        SMSSubmissionHeader hdr = (SMSSubmissionHeader) o;
+        SmsSubmissionHeader hdr = (SmsSubmissionHeader) o;
         return type.equals( hdr.type ) && version == hdr.version && lastSyncDate.equals( hdr.lastSyncDate )
-            && submissionID == hdr.submissionID;
+            && submissionId == hdr.submissionId;
     }
 
     public void validateHeaer()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         // TODO: More validation here
-        if ( submissionID < 0 || submissionID > 255 )
+        if ( submissionId < 0 || submissionId > 255 )
         {
-            throw new SMSCompressionException( "Ensure the Submission ID has been set for this submission" );
+            throw new SmsCompressionException( "Ensure the Submission ID has been set for this submission" );
         }
     }
 
-    public void writeHeader( SMSSubmissionWriter writer )
-        throws SMSCompressionException
+    public void writeHeader( SmsSubmissionWriter writer )
+        throws SmsCompressionException
     {
         writer.writeType( type );
         writer.writeVersion( version );
         writer.writeNonNullableDate( lastSyncDate );
-        writer.writeSubmissionID( submissionID );
+        writer.writeSubmissionId( submissionId );
     }
 
-    public void readHeader( SMSSubmissionReader reader )
-        throws SMSCompressionException
+    public void readHeader( SmsSubmissionReader reader )
+        throws SmsCompressionException
     {
         this.type = reader.readType();
         this.version = reader.readVersion();
         this.lastSyncDate = reader.readNonNullableDate();
-        this.submissionID = reader.readSubmissionID();
+        this.submissionId = reader.readSubmissionId();
     }
 }

--- a/src/main/java/org/hisp/dhis/smscompression/models/SmsValue.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/SmsValue.java
@@ -3,16 +3,16 @@ package org.hisp.dhis.smscompression.models;
 import java.text.ParseException;
 import java.util.Date;
 
-import org.hisp.dhis.smscompression.SMSConsts;
-import org.hisp.dhis.smscompression.SMSConsts.ValueType;
+import org.hisp.dhis.smscompression.SmsConsts;
+import org.hisp.dhis.smscompression.SmsConsts.ValueType;
 
-public class SMSValue<T>
+public class SmsValue<T>
 {
     T value;
 
     ValueType type;
 
-    public SMSValue( T value, ValueType type )
+    public SmsValue( T value, ValueType type )
     {
         this.value = value;
         this.type = type;
@@ -29,20 +29,20 @@ public class SMSValue<T>
         return this.type;
     }
 
-    public static SMSValue<?> asSMSValue( String value )
+    public static SmsValue<?> asSmsValue( String value )
     {
         // BOOL
         if ( value.equals( "true" ) || value.equals( "false" ) )
         {
             Boolean valBool = value.equals( "true" ) ? true : false;
-            return new SMSValue<Boolean>( valBool, ValueType.BOOL );
+            return new SmsValue<Boolean>( valBool, ValueType.BOOL );
         }
 
         // DATE
         try
         {
-            Date valDate = SMSConsts.SIMPLE_DATE_FORMAT.parse( value );
-            return new SMSValue<Date>( valDate, ValueType.DATE );
+            Date valDate = SmsConsts.SIMPLE_DATE_FORMAT.parse( value );
+            return new SmsValue<Date>( valDate, ValueType.DATE );
         }
         catch ( ParseException e )
         {
@@ -53,7 +53,7 @@ public class SMSValue<T>
         try
         {
             Integer valInt = Integer.parseInt( value );
-            return new SMSValue<Integer>( valInt, ValueType.INT );
+            return new SmsValue<Integer>( valInt, ValueType.INT );
         }
         catch ( NumberFormatException e )
         {
@@ -64,7 +64,7 @@ public class SMSValue<T>
         try
         {
             Float valFloat = Float.parseFloat( value );
-            return new SMSValue<Float>( valFloat, ValueType.FLOAT );
+            return new SmsValue<Float>( valFloat, ValueType.FLOAT );
         }
         catch ( NumberFormatException e )
         {
@@ -72,6 +72,6 @@ public class SMSValue<T>
         }
 
         // If all else fails we can use String
-        return new SMSValue<String>( value, ValueType.STRING );
+        return new SmsValue<String>( value, ValueType.STRING );
     }
 }

--- a/src/main/java/org/hisp/dhis/smscompression/models/TrackerEventSmsSubmission.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/TrackerEventSmsSubmission.java
@@ -32,27 +32,29 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
-import org.hisp.dhis.smscompression.SMSCompressionException;
-import org.hisp.dhis.smscompression.SMSConsts;
-import org.hisp.dhis.smscompression.SMSConsts.MetadataType;
-import org.hisp.dhis.smscompression.SMSConsts.SMSEventStatus;
-import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
-import org.hisp.dhis.smscompression.SMSSubmissionReader;
-import org.hisp.dhis.smscompression.SMSSubmissionWriter;
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.SmsConsts;
+import org.hisp.dhis.smscompression.SmsConsts.MetadataType;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEventStatus;
+import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
+import org.hisp.dhis.smscompression.SmsSubmissionReader;
+import org.hisp.dhis.smscompression.SmsSubmissionWriter;
 
-public class SimpleEventSMSSubmission
+public class TrackerEventSmsSubmission
     extends
-    SMSSubmission
+    SmsSubmission
 {
-    protected UID orgUnit;
+    protected Uid orgUnit;
 
-    protected UID eventProgram;
+    protected Uid programStage;
 
-    protected SMSEventStatus eventStatus;
+    protected SmsEventStatus eventStatus;
 
-    protected UID attributeOptionCombo;
+    protected Uid attributeOptionCombo;
 
-    protected UID event;
+    protected Uid enrollment;
+
+    protected Uid event;
 
     protected Date eventDate;
 
@@ -60,58 +62,68 @@ public class SimpleEventSMSSubmission
 
     protected GeoPoint coordinates;
 
-    protected List<SMSDataValue> values;
+    protected List<SmsDataValue> values;
 
     /* Getters and Setters */
 
-    public UID getOrgUnit()
+    public Uid getOrgUnit()
     {
         return orgUnit;
     }
 
     public void setOrgUnit( String orgUnit )
     {
-        this.orgUnit = new UID( orgUnit, MetadataType.ORGANISATION_UNIT );
+        this.orgUnit = new Uid( orgUnit, MetadataType.ORGANISATION_UNIT );
     }
 
-    public UID getEventProgram()
+    public Uid getProgramStage()
     {
-        return eventProgram;
+        return programStage;
     }
 
-    public void setEventProgram( String eventProgram )
+    public void setProgramStage( String programStage )
     {
-        this.eventProgram = new UID( eventProgram, MetadataType.PROGRAM );
+        this.programStage = new Uid( programStage, MetadataType.PROGRAM_STAGE );
     }
 
-    public SMSEventStatus getEventStatus()
+    public SmsEventStatus getEventStatus()
     {
         return eventStatus;
     }
 
-    public void setEventStatus( SMSEventStatus eventStatus )
+    public void setEventStatus( SmsEventStatus eventStatus )
     {
         this.eventStatus = eventStatus;
     }
 
-    public UID getAttributeOptionCombo()
+    public Uid getAttributeOptionCombo()
     {
         return attributeOptionCombo;
     }
 
     public void setAttributeOptionCombo( String attributeOptionCombo )
     {
-        this.attributeOptionCombo = new UID( attributeOptionCombo, MetadataType.CATEGORY_OPTION_COMBO );
+        this.attributeOptionCombo = new Uid( attributeOptionCombo, MetadataType.CATEGORY_OPTION_COMBO );
     }
 
-    public UID getEvent()
+    public Uid getEnrollment()
+    {
+        return enrollment;
+    }
+
+    public void setEnrollment( String enrollment )
+    {
+        this.enrollment = new Uid( enrollment, MetadataType.ENROLLMENT );
+    }
+
+    public Uid getEvent()
     {
         return event;
     }
 
     public void setEvent( String event )
     {
-        this.event = new UID( event, MetadataType.EVENT );
+        this.event = new Uid( event, MetadataType.EVENT );
     }
 
     public Date getEventDate()
@@ -144,12 +156,12 @@ public class SimpleEventSMSSubmission
         this.coordinates = coordinates;
     }
 
-    public List<SMSDataValue> getValues()
+    public List<SmsDataValue> getValues()
     {
         return values;
     }
 
-    public void setValues( List<SMSDataValue> values )
+    public void setValues( List<SmsDataValue> values )
     {
         this.values = values;
     }
@@ -161,20 +173,21 @@ public class SimpleEventSMSSubmission
         {
             return false;
         }
-        SimpleEventSMSSubmission subm = (SimpleEventSMSSubmission) o;
+        TrackerEventSmsSubmission subm = (TrackerEventSmsSubmission) o;
 
-        return Objects.equals( orgUnit, subm.orgUnit ) && Objects.equals( eventProgram, subm.eventProgram )
+        return Objects.equals( orgUnit, subm.orgUnit ) && Objects.equals( programStage, subm.programStage )
             && Objects.equals( eventStatus, subm.eventStatus )
-            && Objects.equals( attributeOptionCombo, subm.attributeOptionCombo ) && Objects.equals( event, subm.event )
-            && Objects.equals( eventDate, subm.eventDate ) && Objects.equals( dueDate, subm.dueDate )
-            && Objects.equals( coordinates, subm.coordinates ) && Objects.equals( values, subm.values );
+            && Objects.equals( attributeOptionCombo, subm.attributeOptionCombo ) && enrollment.equals( subm.enrollment )
+            && Objects.equals( event, subm.event ) && Objects.equals( eventDate, subm.eventDate )
+            && Objects.equals( dueDate, subm.dueDate ) && Objects.equals( coordinates, subm.coordinates )
+            && Objects.equals( values, subm.values );
     }
 
     /* Implementation of abstract methods */
 
     @Override
-    public void writeSubm( SMSSubmissionWriter writer, int version )
-        throws SMSCompressionException
+    public void writeSubm( SmsSubmissionWriter writer, int version )
+        throws SmsCompressionException
     {
         switch ( version )
         {
@@ -185,30 +198,32 @@ public class SimpleEventSMSSubmission
             writeSubmV2( writer );
             break;
         default:
-            throw new SMSCompressionException( versionError( version ) );
+            throw new SmsCompressionException( versionError( version ) );
         }
     }
 
-    private void writeSubmV1( SMSSubmissionWriter writer )
-        throws SMSCompressionException
+    private void writeSubmV1( SmsSubmissionWriter writer )
+        throws SmsCompressionException
     {
-        writer.writeID( orgUnit );
-        writer.writeID( eventProgram );
+        writer.writeId( orgUnit );
+        writer.writeId( programStage );
         writer.writeEventStatus( eventStatus );
-        writer.writeID( attributeOptionCombo );
-        writer.writeID( event );
+        writer.writeId( attributeOptionCombo );
+        writer.writeId( enrollment );
+        writer.writeId( event );
         writer.writeNonNullableDate( eventDate );
         writer.writeDataValues( values );
     }
 
-    private void writeSubmV2( SMSSubmissionWriter writer )
-        throws SMSCompressionException
+    private void writeSubmV2( SmsSubmissionWriter writer )
+        throws SmsCompressionException
     {
-        writer.writeID( orgUnit );
-        writer.writeID( eventProgram );
+        writer.writeId( orgUnit );
+        writer.writeId( programStage );
         writer.writeEventStatus( eventStatus );
-        writer.writeID( attributeOptionCombo );
-        writer.writeID( event );
+        writer.writeId( attributeOptionCombo );
+        writer.writeId( enrollment );
+        writer.writeId( event );
         writer.writeDate( eventDate );
         writer.writeDate( dueDate );
         writer.writeGeoPoint( coordinates );
@@ -221,8 +236,8 @@ public class SimpleEventSMSSubmission
     }
 
     @Override
-    public void readSubm( SMSSubmissionReader reader, int version )
-        throws SMSCompressionException
+    public void readSubm( SmsSubmissionReader reader, int version )
+        throws SmsCompressionException
     {
         switch ( version )
         {
@@ -233,30 +248,32 @@ public class SimpleEventSMSSubmission
             readSubmV2( reader );
             break;
         default:
-            throw new SMSCompressionException( versionError( version ) );
+            throw new SmsCompressionException( versionError( version ) );
         }
     }
 
-    private void readSubmV1( SMSSubmissionReader reader )
-        throws SMSCompressionException
+    private void readSubmV1( SmsSubmissionReader reader )
+        throws SmsCompressionException
     {
-        this.orgUnit = reader.readID( MetadataType.ORGANISATION_UNIT );
-        this.eventProgram = reader.readID( MetadataType.PROGRAM );
+        this.orgUnit = reader.readId( MetadataType.ORGANISATION_UNIT );
+        this.programStage = reader.readId( MetadataType.PROGRAM_STAGE );
         this.eventStatus = reader.readEventStatus();
-        this.attributeOptionCombo = reader.readID( MetadataType.CATEGORY_OPTION_COMBO );
-        this.event = reader.readID( MetadataType.EVENT );
+        this.attributeOptionCombo = reader.readId( MetadataType.CATEGORY_OPTION_COMBO );
+        this.enrollment = reader.readId( MetadataType.ENROLLMENT );
+        this.event = reader.readId( MetadataType.EVENT );
         this.eventDate = reader.readNonNullableDate();
         this.values = reader.readDataValues();
     }
 
-    private void readSubmV2( SMSSubmissionReader reader )
-        throws SMSCompressionException
+    private void readSubmV2( SmsSubmissionReader reader )
+        throws SmsCompressionException
     {
-        this.orgUnit = reader.readID( MetadataType.ORGANISATION_UNIT );
-        this.eventProgram = reader.readID( MetadataType.PROGRAM );
+        this.orgUnit = reader.readId( MetadataType.ORGANISATION_UNIT );
+        this.programStage = reader.readId( MetadataType.PROGRAM_STAGE );
         this.eventStatus = reader.readEventStatus();
-        this.attributeOptionCombo = reader.readID( MetadataType.CATEGORY_OPTION_COMBO );
-        this.event = reader.readID( MetadataType.EVENT );
+        this.attributeOptionCombo = reader.readId( MetadataType.CATEGORY_OPTION_COMBO );
+        this.enrollment = reader.readId( MetadataType.ENROLLMENT );
+        this.event = reader.readId( MetadataType.EVENT );
         this.eventDate = reader.readDate();
         this.dueDate = reader.readDate();
         this.coordinates = reader.readGeoPoint();
@@ -273,6 +290,6 @@ public class SimpleEventSMSSubmission
     @Override
     public SubmissionType getType()
     {
-        return SMSConsts.SubmissionType.SIMPLE_EVENT;
+        return SmsConsts.SubmissionType.TRACKER_EVENT;
     }
 }

--- a/src/main/java/org/hisp/dhis/smscompression/models/Uid.java
+++ b/src/main/java/org/hisp/dhis/smscompression/models/Uid.java
@@ -1,9 +1,9 @@
 package org.hisp.dhis.smscompression.models;
 
-import org.hisp.dhis.smscompression.SMSConsts.MetadataType;
-import org.hisp.dhis.smscompression.utils.IDUtil;
+import org.hisp.dhis.smscompression.SmsConsts.MetadataType;
+import org.hisp.dhis.smscompression.utils.IdUtil;
 
-public class UID
+public class Uid
 {
     private String uid;
 
@@ -11,13 +11,13 @@ public class UID
 
     private MetadataType type;
 
-    public UID( String uid, MetadataType type )
+    public Uid( String uid, MetadataType type )
     {
         this.uid = uid;
         this.type = type;
     }
 
-    public UID( String uid, int hash, MetadataType type )
+    public Uid( String uid, int hash, MetadataType type )
     {
         this.uid = uid;
         this.hash = hash;
@@ -29,7 +29,7 @@ public class UID
         return hash;
     }
 
-    public String getUID()
+    public String getUid()
     {
         return uid;
     }
@@ -41,7 +41,7 @@ public class UID
 
     public String getHashAsBase64()
     {
-        return ("#" + IDUtil.hashAsBase64( this ));
+        return ("#" + IdUtil.hashAsBase64( this ));
     }
 
     @Override
@@ -63,7 +63,7 @@ public class UID
         {
             return false;
         }
-        UID u = (UID) o;
+        Uid u = (Uid) o;
         return uid.equals( u.uid ) && (type == u.type);
     }
 

--- a/src/main/java/org/hisp/dhis/smscompression/utils/BitInputStream.java
+++ b/src/main/java/org/hisp/dhis/smscompression/utils/BitInputStream.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
 
-import org.hisp.dhis.smscompression.SMSCompressionException;
+import org.hisp.dhis.smscompression.SmsCompressionException;
 
 /**
  * A stream of bits that can be read. Because they come from an underlying byte
@@ -91,11 +91,11 @@ public final class BitInputStream
      * Throws an EOFException if the end of the stream is reached.
      * 
      * @return the next n bits as an integer
-     * @throws SMSCompressionException if an I/O exception or EOF exception
+     * @throws SmsCompressionException if an I/O exception or EOF exception
      *         occurred
      */
     public int read( int n )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         try
         {
@@ -110,7 +110,7 @@ public final class BitInputStream
         }
         catch ( IOException e )
         {
-            throw new SMSCompressionException( e );
+            throw new SmsCompressionException( e );
         }
     }
 

--- a/src/main/java/org/hisp/dhis/smscompression/utils/BitOutputStream.java
+++ b/src/main/java/org/hisp/dhis/smscompression/utils/BitOutputStream.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Objects;
 
-import org.hisp.dhis.smscompression.SMSCompressionException;
+import org.hisp.dhis.smscompression.SmsCompressionException;
 
 /**
  * A stream where bits can be written to. Because they are written to an
@@ -90,7 +90,7 @@ public final class BitOutputStream
      * @throws IOException if an I/O exception occurred
      */
     public void write( int i, int n )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         try
         {
@@ -107,7 +107,7 @@ public final class BitOutputStream
         }
         catch ( IOException e )
         {
-            throw new SMSCompressionException( e );
+            throw new SmsCompressionException( e );
         }
     }
 

--- a/src/main/java/org/hisp/dhis/smscompression/utils/ValueUtil.java
+++ b/src/main/java/org/hisp/dhis/smscompression/utils/ValueUtil.java
@@ -3,19 +3,19 @@ package org.hisp.dhis.smscompression.utils;
 import java.util.Date;
 import java.util.List;
 
-import org.hisp.dhis.smscompression.SMSCompressionException;
-import org.hisp.dhis.smscompression.SMSConsts;
-import org.hisp.dhis.smscompression.SMSConsts.ValueType;
-import org.hisp.dhis.smscompression.models.SMSValue;
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.SmsConsts;
+import org.hisp.dhis.smscompression.SmsConsts.ValueType;
+import org.hisp.dhis.smscompression.models.SmsValue;
 
 public class ValueUtil
 {
     // TODO: Find a better way to pass down fixedIntBitLen
-    public static void writeSMSValue( SMSValue<?> val, int fixedIntBitlen, BitOutputStream outStream )
-        throws SMSCompressionException
+    public static void writeSmsValue( SmsValue<?> val, int fixedIntBitlen, BitOutputStream outStream )
+        throws SmsCompressionException
     {
         // First write out the value type
-        outStream.write( val.getType().ordinal(), SMSConsts.VALTYPE_BITLEN );
+        outStream.write( val.getType().ordinal(), SmsConsts.VALTYPE_BITLEN );
 
         // Now write out the actual value
         switch ( val.getType() )
@@ -39,62 +39,62 @@ public class ValueUtil
     }
 
     // TODO: Find a better way to pass down fixedIntBitLen
-    public static SMSValue<?> readSMSValue( int fixedIntBitLen, BitInputStream inStream )
-        throws SMSCompressionException
+    public static SmsValue<?> readSmsValue( int fixedIntBitLen, BitInputStream inStream )
+        throws SmsCompressionException
     {
         // First read the value type
-        int typeNum = inStream.read( SMSConsts.VALTYPE_BITLEN );
+        int typeNum = inStream.read( SmsConsts.VALTYPE_BITLEN );
         ValueType type = ValueType.values()[typeNum];
 
         // Now read the actual value
         switch ( type )
         {
         case BOOL:
-            return new SMSValue<Boolean>( readBool( inStream ), type );
+            return new SmsValue<Boolean>( readBool( inStream ), type );
         case DATE:
-            return new SMSValue<Date>( readDate( inStream ), type );
+            return new SmsValue<Date>( readDate( inStream ), type );
         case INT:
-            return new SMSValue<Integer>( readInt( fixedIntBitLen, inStream ), type );
+            return new SmsValue<Integer>( readInt( fixedIntBitLen, inStream ), type );
         case FLOAT:
-            return new SMSValue<Float>( readFloat( inStream ), type );
+            return new SmsValue<Float>( readFloat( inStream ), type );
         case STRING:
-            return new SMSValue<String>( readString( inStream ), type );
+            return new SmsValue<String>( readString( inStream ), type );
         default:
-            throw new SMSCompressionException( "Unknown ValueType: " + type );
+            throw new SmsCompressionException( "Unknown ValueType: " + type );
         }
     }
 
     public static void writeBool( boolean val, BitOutputStream outStream )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         int intVal = val ? 1 : 0;
         outStream.write( intVal, 1 );
     }
 
     public static boolean readBool( BitInputStream inStream )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         int intVal = inStream.read( 1 );
         return intVal == 1;
     }
 
     public static void writeDate( Date d, BitOutputStream outStream )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         long epochSecs = d.getTime() / 1000;
-        outStream.write( (int) epochSecs, SMSConsts.EPOCH_DATE_BITLEN );
+        outStream.write( (int) epochSecs, SmsConsts.EPOCH_DATE_BITLEN );
     }
 
     public static Date readDate( BitInputStream inStream )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
-        long epochSecs = inStream.read( SMSConsts.EPOCH_DATE_BITLEN );
+        long epochSecs = inStream.read( SmsConsts.EPOCH_DATE_BITLEN );
         Date dateVal = new Date( epochSecs * 1000 );
         return dateVal;
     }
 
     public static void writeInt( int val, int fixedIntBitlen, BitOutputStream outStream )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         // We can't write negative ints so we handle sign separately
         int isNegative = val < 0 ? 1 : 0;
@@ -102,12 +102,12 @@ public class ValueUtil
         val = Math.abs( val );
 
         // If it's bigger than the fixedInt size we need to give its size
-        int isVariable = val > SMSConsts.MAX_FIXED_NUM ? 1 : 0;
+        int isVariable = val > SmsConsts.MAX_FIXED_NUM ? 1 : 0;
         outStream.write( isVariable, 1 );
         int intBitlen = BinaryUtils.bitlenNeeded( val );
 
         if ( isVariable == 1 )
-            outStream.write( intBitlen, SMSConsts.VARLEN_BITLEN );
+            outStream.write( intBitlen, SmsConsts.VARLEN_BITLEN );
 
         int bitLen = isVariable == 1 ? intBitlen : fixedIntBitlen;
 
@@ -115,7 +115,7 @@ public class ValueUtil
     }
 
     public static int readInt( int fixedIntBitlen, BitInputStream inStream )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         // Is this int negative?
         int setNegative = inStream.read( 1 ) == 1 ? -1 : 1;
@@ -123,42 +123,42 @@ public class ValueUtil
         // Is this int fixed or variable size?
         int isVariable = inStream.read( 1 );
 
-        int bitLen = isVariable == 1 ? inStream.read( SMSConsts.VARLEN_BITLEN ) : fixedIntBitlen;
+        int bitLen = isVariable == 1 ? inStream.read( SmsConsts.VARLEN_BITLEN ) : fixedIntBitlen;
         return setNegative * inStream.read( bitLen );
     }
 
     public static void writeFloat( float val, BitOutputStream outStream )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         // TODO: We need to handle floats better
         writeString( Float.toString( val ), outStream );
     }
 
     public static float readFloat( BitInputStream inStream )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         // TODO: We need to handle floats better
         return Float.parseFloat( readString( inStream ) );
     }
 
     public static void writeString( String s, BitOutputStream outStream )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         for ( char c : s.toCharArray() )
         {
-            outStream.write( c, SMSConsts.CHAR_BITLEN );
+            outStream.write( c, SmsConsts.CHAR_BITLEN );
         }
         // Null terminator
-        outStream.write( 0, SMSConsts.CHAR_BITLEN );
+        outStream.write( 0, SmsConsts.CHAR_BITLEN );
     }
 
     public static String readString( BitInputStream inStream )
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         String s = "";
         do
         {
-            int i = inStream.read( SMSConsts.CHAR_BITLEN );
+            int i = inStream.read( SmsConsts.CHAR_BITLEN );
             if ( i == 0 )
                 break;
             s += (char) i;
@@ -167,15 +167,15 @@ public class ValueUtil
         return s;
     }
 
-    public static int getBitlenLargestInt( List<SMSValue<?>> values )
+    public static int getBitlenLargestInt( List<SmsValue<?>> values )
     {
         int maxInt = 0;
-        for ( SMSValue<?> val : values )
+        for ( SmsValue<?> val : values )
         {
             if ( val.getType() == ValueType.INT )
             {
                 int intVal = Math.abs( (Integer) val.getValue() );
-                if ( intVal > SMSConsts.MAX_FIXED_NUM )
+                if ( intVal > SmsConsts.MAX_FIXED_NUM )
                     continue;
                 maxInt = intVal > maxInt ? intVal : maxInt;
             }

--- a/src/test/java/org/hisp/dhis/smscompression/CreateSubm.java
+++ b/src/test/java/org/hisp/dhis/smscompression/CreateSubm.java
@@ -2,104 +2,104 @@ package org.hisp.dhis.smscompression;
 
 import java.util.ArrayList;
 
-import org.hisp.dhis.smscompression.SMSConsts.SMSEnrollmentStatus;
-import org.hisp.dhis.smscompression.SMSConsts.SMSEventStatus;
-import org.hisp.dhis.smscompression.models.AggregateDatasetSMSSubmission;
-import org.hisp.dhis.smscompression.models.DeleteSMSSubmission;
-import org.hisp.dhis.smscompression.models.EnrollmentSMSSubmission;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEnrollmentStatus;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEventStatus;
+import org.hisp.dhis.smscompression.models.AggregateDatasetSmsSubmission;
+import org.hisp.dhis.smscompression.models.DeleteSmsSubmission;
+import org.hisp.dhis.smscompression.models.EnrollmentSmsSubmission;
 import org.hisp.dhis.smscompression.models.GeoPoint;
-import org.hisp.dhis.smscompression.models.RelationshipSMSSubmission;
-import org.hisp.dhis.smscompression.models.SMSAttributeValue;
-import org.hisp.dhis.smscompression.models.SMSDataValue;
-import org.hisp.dhis.smscompression.models.SimpleEventSMSSubmission;
-import org.hisp.dhis.smscompression.models.TrackerEventSMSSubmission;
+import org.hisp.dhis.smscompression.models.RelationshipSmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsAttributeValue;
+import org.hisp.dhis.smscompression.models.SmsDataValue;
+import org.hisp.dhis.smscompression.models.SimpleEventSmsSubmission;
+import org.hisp.dhis.smscompression.models.TrackerEventSmsSubmission;
 
 public class CreateSubm
 {
-    public static DeleteSMSSubmission createDeleteSubmission()
+    public static DeleteSmsSubmission createDeleteSubmission()
     {
-        DeleteSMSSubmission subm = new DeleteSMSSubmission();
+        DeleteSmsSubmission subm = new DeleteSmsSubmission();
 
-        subm.setUserID( "GOLswS44mh8" ); // Tom Wakiki (system)
+        subm.setUserId( "GOLswS44mh8" ); // Tom Wakiki (system)
         subm.setEvent( "Jpr20TLJ7Z1" ); // Generated UID of test event
-        subm.setSubmissionID( 1 );
+        subm.setSubmissionId( 1 );
 
         return subm;
     }
 
-    public static RelationshipSMSSubmission createRelationshipSubmission()
+    public static RelationshipSmsSubmission createRelationshipSubmission()
     {
-        RelationshipSMSSubmission subm = new RelationshipSMSSubmission();
+        RelationshipSmsSubmission subm = new RelationshipSmsSubmission();
 
-        subm.setUserID( "GOLswS44mh8" ); // Tom Wakiki (system)
+        subm.setUserId( "GOLswS44mh8" ); // Tom Wakiki (system)
         subm.setRelationshipType( "XdP5nraLPZ0" ); // Sibling_a-to-b_(Person-Person)
         subm.setRelationship( "uf3svrmpzOj" ); // Generated UID for new
                                                // relationship
         subm.setFrom( "qv0j4JBXQX0" ); // Gloria Murray (Person)
         subm.setTo( "LSEjy8nA3kY" ); // Jerald Wilson (Person)
-        subm.setSubmissionID( 1 );
+        subm.setSubmissionId( 1 );
 
         return subm;
     }
 
-    public static SimpleEventSMSSubmission createSimpleEventSubmission()
+    public static SimpleEventSmsSubmission createSimpleEventSubmission()
     {
-        SimpleEventSMSSubmission subm = new SimpleEventSMSSubmission();
+        SimpleEventSmsSubmission subm = new SimpleEventSmsSubmission();
 
-        subm.setUserID( "GOLswS44mh8" ); // Tom Wakiki (system)
+        subm.setUserId( "GOLswS44mh8" ); // Tom Wakiki (system)
         subm.setOrgUnit( "DiszpKrYNg8" ); // Ngelehun CHC
         subm.setEventProgram( "lxAQ7Zs9VYR" ); // Antenatal Care Visit
-        subm.setEventStatus( SMSEventStatus.COMPLETED );
+        subm.setEventStatus( SmsEventStatus.COMPLETED );
         subm.setAttributeOptionCombo( "HllvX50cXC0" ); // Default catOptionCombo
         subm.setEvent( "l7M1gUFK37v" ); // New UID
         subm.setEventDate( TestUtils.getNowWithoutMillis() );
         subm.setDueDate( TestUtils.getNowWithoutMillis() );
         subm.setCoordinates( new GeoPoint( 8.4844694f, -13.2364332f ) );
-        ArrayList<SMSDataValue> values = new ArrayList<>();
-        values.add( new SMSDataValue( "HllvX50cXC0", "sWoqcoByYmD", "true" ) ); // WHOMCH
+        ArrayList<SmsDataValue> values = new ArrayList<>();
+        values.add( new SmsDataValue( "HllvX50cXC0", "sWoqcoByYmD", "true" ) ); // WHOMCH
                                                                                 // Smoking
-        values.add( new SMSDataValue( "HllvX50cXC0", "Ok9OQpitjQr", "false" ) ); // WHOMCH
+        values.add( new SmsDataValue( "HllvX50cXC0", "Ok9OQpitjQr", "false" ) ); // WHOMCH
                                                                                  // Smoking
                                                                                  // cessation
                                                                                  // counselling
                                                                                  // provided
-        values.add( new SMSDataValue( "HllvX50cXC0", "vANAXwtLwcT", "14" ) ); // WHOMCH
+        values.add( new SmsDataValue( "HllvX50cXC0", "vANAXwtLwcT", "14" ) ); // WHOMCH
                                                                               // Hemoglobin
                                                                               // value
         subm.setValues( values );
-        subm.setSubmissionID( 1 );
+        subm.setSubmissionId( 1 );
 
         return subm;
     }
 
-    public static AggregateDatasetSMSSubmission createAggregateDatasetSubmission()
+    public static AggregateDatasetSmsSubmission createAggregateDatasetSubmission()
     {
-        AggregateDatasetSMSSubmission subm = new AggregateDatasetSMSSubmission();
+        AggregateDatasetSmsSubmission subm = new AggregateDatasetSmsSubmission();
 
-        subm.setUserID( "GOLswS44mh8" ); // Tom Wakiki (system)
+        subm.setUserId( "GOLswS44mh8" ); // Tom Wakiki (system)
         subm.setOrgUnit( "DiszpKrYNg8" ); // Ngelehun CHC
         subm.setDataSet( "Nyh6laLdBEJ" ); // IDSR Weekly
         subm.setComplete( true );
         subm.setAttributeOptionCombo( "HllvX50cXC0" );
         subm.setPeriod( "2019W16" );
-        ArrayList<SMSDataValue> values = new ArrayList<>();
-        values.add( new SMSDataValue( "HllvX50cXC0", "UsSUX0cpKsH", "0" ) ); // Cholera
-        values.add( new SMSDataValue( "HllvX50cXC0", "HS9zqaBdOQ4", "-65535" ) ); // Plague
-        values.add( new SMSDataValue( "HllvX50cXC0", "noIzB569hTM", "12345678" ) ); // Yellow
+        ArrayList<SmsDataValue> values = new ArrayList<>();
+        values.add( new SmsDataValue( "HllvX50cXC0", "UsSUX0cpKsH", "0" ) ); // Cholera
+        values.add( new SmsDataValue( "HllvX50cXC0", "HS9zqaBdOQ4", "-65535" ) ); // Plague
+        values.add( new SmsDataValue( "HllvX50cXC0", "noIzB569hTM", "12345678" ) ); // Yellow
                                                                                     // Fever
-        values.add( new SMSDataValue( "HllvX50cXC0", "vq2qO3eTrNi", "-24.5" ) ); // Malaria
-        values.add( new SMSDataValue( "HllvX50cXC0", "YazgqXbizv1", "0.12345678" ) ); // Measles
+        values.add( new SmsDataValue( "HllvX50cXC0", "vq2qO3eTrNi", "-24.5" ) ); // Malaria
+        values.add( new SmsDataValue( "HllvX50cXC0", "YazgqXbizv1", "0.12345678" ) ); // Measles
         subm.setValues( values );
-        subm.setSubmissionID( 1 );
+        subm.setSubmissionId( 1 );
 
         return subm;
     }
 
-    public static EnrollmentSMSSubmission createEnrollmentSubmission()
+    public static EnrollmentSmsSubmission createEnrollmentSubmission()
     {
-        EnrollmentSMSSubmission subm = new EnrollmentSMSSubmission();
+        EnrollmentSmsSubmission subm = new EnrollmentSmsSubmission();
 
-        subm.setUserID( "GOLswS44mh8" ); // Tom Wakiki (system)
+        subm.setUserId( "GOLswS44mh8" ); // Tom Wakiki (system)
         subm.setOrgUnit( "DiszpKrYNg8" ); // Ngelehun CHC
         subm.setTrackerProgram( "IpHINAT79UW" ); // Child Programme
         subm.setTrackedEntityType( "nEenWmSyUEp" ); // Person
@@ -108,49 +108,49 @@ public class CreateSubm
         subm.setEnrollmentDate( TestUtils.getNowWithoutMillis() );
         subm.setIncidentDate( TestUtils.getNowWithoutMillis() );
         subm.setCoordinates( new GeoPoint( 8.4844694f, -13.2364332f ) );
-        subm.setEnrollmentStatus( SMSEnrollmentStatus.ACTIVE );
-        ArrayList<SMSAttributeValue> values = new ArrayList<>();
-        values.add( new SMSAttributeValue( "w75KJ2mc4zz", "Harold" ) ); // First
+        subm.setEnrollmentStatus( SmsEnrollmentStatus.ACTIVE );
+        ArrayList<SmsAttributeValue> values = new ArrayList<>();
+        values.add( new SmsAttributeValue( "w75KJ2mc4zz", "Harold" ) ); // First
                                                                         // Name
-        values.add( new SMSAttributeValue( "zDhUuAYrxNC", "Smith" ) ); // Last
+        values.add( new SmsAttributeValue( "zDhUuAYrxNC", "Smith" ) ); // Last
                                                                        // Name
-        values.add( new SMSAttributeValue( "FO4sWYJ64LQ", "Sydney" ) ); // City
-        values.add( new SMSAttributeValue( "VqEFza8wbwA", "The Opera House" ) ); // Address
-        values.add( new SMSAttributeValue( "lZGmxYbs97q", "987123" ) ); // Unique
+        values.add( new SmsAttributeValue( "FO4sWYJ64LQ", "Sydney" ) ); // City
+        values.add( new SmsAttributeValue( "VqEFza8wbwA", "The Opera House" ) ); // Address
+        values.add( new SmsAttributeValue( "lZGmxYbs97q", "987123" ) ); // Unique
                                                                         // ID
         subm.setValues( values );
-        subm.setSubmissionID( 1 );
+        subm.setSubmissionId( 1 );
 
         subm.setEvents( TestUtils.createEventList() );
 
         return subm;
     }
 
-    public static TrackerEventSMSSubmission createTrackerEventSubmission()
+    public static TrackerEventSmsSubmission createTrackerEventSubmission()
     {
-        TrackerEventSMSSubmission subm = new TrackerEventSMSSubmission();
+        TrackerEventSmsSubmission subm = new TrackerEventSmsSubmission();
 
-        subm.setUserID( "GOLswS44mh8" ); // Tom Wakiki (system)
+        subm.setUserId( "GOLswS44mh8" ); // Tom Wakiki (system)
         subm.setOrgUnit( "DiszpKrYNg8" ); // Ngelehun CHC
         subm.setProgramStage( "A03MvHHogjR" ); // Birth
         subm.setAttributeOptionCombo( "HllvX50cXC0" ); // Default catOptionCombo
         subm.setEnrollment( "DacGG5vK1K6" ); // Test Person
         subm.setEvent( "r7M1gUFK37v" ); // New UID
-        subm.setEventStatus( SMSEventStatus.COMPLETED );
+        subm.setEventStatus( SmsEventStatus.COMPLETED );
         subm.setEventDate( TestUtils.getNowWithoutMillis() );
         subm.setDueDate( TestUtils.getNowWithoutMillis() );
         subm.setCoordinates( new GeoPoint( 8.4844694f, -13.2364332f ) );
-        ArrayList<SMSDataValue> values = new ArrayList<>();
-        values.add( new SMSDataValue( "HllvX50cXC0", "a3kGcGDCuk6", "10" ) ); // Apgar
+        ArrayList<SmsDataValue> values = new ArrayList<>();
+        values.add( new SmsDataValue( "HllvX50cXC0", "a3kGcGDCuk6", "10" ) ); // Apgar
                                                                               // score
 
-        values.add( new SMSDataValue( "HllvX50cXC0", "wQLfBvPrXqq", "Others" ) ); // ARV
+        values.add( new SmsDataValue( "HllvX50cXC0", "wQLfBvPrXqq", "Others" ) ); // ARV
                                                                                   // at
                                                                                   // birth
-        values.add( new SMSDataValue( "HllvX50cXC0", "X8zyunlgUfM", "Exclusive" ) ); // Infant
+        values.add( new SmsDataValue( "HllvX50cXC0", "X8zyunlgUfM", "Exclusive" ) ); // Infant
                                                                                      // feeding
         subm.setValues( values );
-        subm.setSubmissionID( 1 );
+        subm.setSubmissionId( 1 );
 
         return subm;
     }

--- a/src/test/java/org/hisp/dhis/smscompression/CreateSubmV1.java
+++ b/src/test/java/org/hisp/dhis/smscompression/CreateSubmV1.java
@@ -2,92 +2,92 @@ package org.hisp.dhis.smscompression;
 
 import java.util.ArrayList;
 
-import org.hisp.dhis.smscompression.SMSConsts.SMSEventStatus;
-import org.hisp.dhis.smscompression.models.EnrollmentSMSSubmission;
-import org.hisp.dhis.smscompression.models.SMSAttributeValue;
-import org.hisp.dhis.smscompression.models.SMSDataValue;
-import org.hisp.dhis.smscompression.models.SimpleEventSMSSubmission;
-import org.hisp.dhis.smscompression.models.TrackerEventSMSSubmission;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEventStatus;
+import org.hisp.dhis.smscompression.models.EnrollmentSmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsAttributeValue;
+import org.hisp.dhis.smscompression.models.SmsDataValue;
+import org.hisp.dhis.smscompression.models.SimpleEventSmsSubmission;
+import org.hisp.dhis.smscompression.models.TrackerEventSmsSubmission;
 
 public class CreateSubmV1
 {
-    public static EnrollmentSMSSubmission createEnrollmentSubmissionV1()
+    public static EnrollmentSmsSubmission createEnrollmentSubmissionV1()
     {
-        EnrollmentSMSSubmission subm = new EnrollmentSMSSubmission();
+        EnrollmentSmsSubmission subm = new EnrollmentSmsSubmission();
 
-        subm.setUserID( "GOLswS44mh8" ); // Tom Wakiki (system)
+        subm.setUserId( "GOLswS44mh8" ); // Tom Wakiki (system)
         subm.setOrgUnit( "DiszpKrYNg8" ); // Ngelehun CHC
         subm.setTrackerProgram( "IpHINAT79UW" ); // Child Programme
         subm.setTrackedEntityType( "nEenWmSyUEp" ); // Person
         subm.setTrackedEntityInstance( "T2bRuLEGoVN" ); // Newly generated UID
         subm.setEnrollment( "p7M1gUFK37W" ); // Newly generated UID
         subm.setEnrollmentDate( TestUtils.getNowWithoutMillis() );
-        ArrayList<SMSAttributeValue> values = new ArrayList<>();
-        values.add( new SMSAttributeValue( "w75KJ2mc4zz", "Harold" ) ); // First
+        ArrayList<SmsAttributeValue> values = new ArrayList<>();
+        values.add( new SmsAttributeValue( "w75KJ2mc4zz", "Harold" ) ); // First
                                                                         // Name
-        values.add( new SMSAttributeValue( "zDhUuAYrxNC", "Smith" ) ); // Last
+        values.add( new SmsAttributeValue( "zDhUuAYrxNC", "Smith" ) ); // Last
                                                                        // Name
-        values.add( new SMSAttributeValue( "FO4sWYJ64LQ", "Sydney" ) ); // City
-        values.add( new SMSAttributeValue( "VqEFza8wbwA", "The Opera House" ) ); // Address
-        values.add( new SMSAttributeValue( "lZGmxYbs97q", "987123" ) ); // Unique
+        values.add( new SmsAttributeValue( "FO4sWYJ64LQ", "Sydney" ) ); // City
+        values.add( new SmsAttributeValue( "VqEFza8wbwA", "The Opera House" ) ); // Address
+        values.add( new SmsAttributeValue( "lZGmxYbs97q", "987123" ) ); // Unique
                                                                         // ID
         subm.setValues( values );
-        subm.setSubmissionID( 1 );
+        subm.setSubmissionId( 1 );
 
         return subm;
     }
 
-    public static SimpleEventSMSSubmission createSimpleEventSubmissionV1()
+    public static SimpleEventSmsSubmission createSimpleEventSubmissionV1()
     {
-        SimpleEventSMSSubmission subm = new SimpleEventSMSSubmission();
+        SimpleEventSmsSubmission subm = new SimpleEventSmsSubmission();
 
-        subm.setUserID( "GOLswS44mh8" ); // Tom Wakiki (system)
+        subm.setUserId( "GOLswS44mh8" ); // Tom Wakiki (system)
         subm.setOrgUnit( "DiszpKrYNg8" ); // Ngelehun CHC
         subm.setEventProgram( "lxAQ7Zs9VYR" ); // Antenatal Care Visit
-        subm.setEventStatus( SMSEventStatus.COMPLETED );
+        subm.setEventStatus( SmsEventStatus.COMPLETED );
         subm.setAttributeOptionCombo( "HllvX50cXC0" ); // Default catOptionCombo
         subm.setEvent( "l7M1gUFK37v" ); // New UID
         subm.setEventDate( TestUtils.getNowWithoutMillis() );
-        ArrayList<SMSDataValue> values = new ArrayList<>();
-        values.add( new SMSDataValue( "HllvX50cXC0", "sWoqcoByYmD", "true" ) ); // WHOMCH
+        ArrayList<SmsDataValue> values = new ArrayList<>();
+        values.add( new SmsDataValue( "HllvX50cXC0", "sWoqcoByYmD", "true" ) ); // WHOMCH
                                                                                 // Smoking
-        values.add( new SMSDataValue( "HllvX50cXC0", "Ok9OQpitjQr", "false" ) ); // WHOMCH
+        values.add( new SmsDataValue( "HllvX50cXC0", "Ok9OQpitjQr", "false" ) ); // WHOMCH
                                                                                  // Smoking
                                                                                  // cessation
                                                                                  // counselling
                                                                                  // provided
-        values.add( new SMSDataValue( "HllvX50cXC0", "vANAXwtLwcT", "14" ) ); // WHOMCH
+        values.add( new SmsDataValue( "HllvX50cXC0", "vANAXwtLwcT", "14" ) ); // WHOMCH
                                                                               // Hemoglobin
                                                                               // value
         subm.setValues( values );
-        subm.setSubmissionID( 1 );
+        subm.setSubmissionId( 1 );
 
         return subm;
     }
 
-    public static TrackerEventSMSSubmission createTrackerEventSubmissionV1()
+    public static TrackerEventSmsSubmission createTrackerEventSubmissionV1()
     {
-        TrackerEventSMSSubmission subm = new TrackerEventSMSSubmission();
+        TrackerEventSmsSubmission subm = new TrackerEventSmsSubmission();
 
-        subm.setUserID( "GOLswS44mh8" ); // Tom Wakiki (system)
+        subm.setUserId( "GOLswS44mh8" ); // Tom Wakiki (system)
         subm.setOrgUnit( "DiszpKrYNg8" ); // Ngelehun CHC
         subm.setProgramStage( "A03MvHHogjR" ); // Birth
         subm.setAttributeOptionCombo( "HllvX50cXC0" ); // Default catOptionCombo
         subm.setEnrollment( "DacGG5vK1K6" ); // Test Person
         subm.setEvent( "r7M1gUFK37v" ); // New UID
-        subm.setEventStatus( SMSEventStatus.COMPLETED );
+        subm.setEventStatus( SmsEventStatus.COMPLETED );
         subm.setEventDate( TestUtils.getNowWithoutMillis() );
-        ArrayList<SMSDataValue> values = new ArrayList<>();
-        values.add( new SMSDataValue( "HllvX50cXC0", "a3kGcGDCuk6", "10" ) ); // Apgar
+        ArrayList<SmsDataValue> values = new ArrayList<>();
+        values.add( new SmsDataValue( "HllvX50cXC0", "a3kGcGDCuk6", "10" ) ); // Apgar
                                                                               // score
 
-        values.add( new SMSDataValue( "HllvX50cXC0", "wQLfBvPrXqq", "Others" ) ); // ARV
+        values.add( new SmsDataValue( "HllvX50cXC0", "wQLfBvPrXqq", "Others" ) ); // ARV
                                                                                   // at
                                                                                   // birth
-        values.add( new SMSDataValue( "HllvX50cXC0", "X8zyunlgUfM", "Exclusive" ) ); // Infant
+        values.add( new SmsDataValue( "HllvX50cXC0", "X8zyunlgUfM", "Exclusive" ) ); // Infant
                                                                                      // feeding
         subm.setValues( values );
-        subm.setSubmissionID( 1 );
+        subm.setSubmissionId( 1 );
 
         return subm;
     }

--- a/src/test/java/org/hisp/dhis/smscompression/TestCustomMetadata.java
+++ b/src/test/java/org/hisp/dhis/smscompression/TestCustomMetadata.java
@@ -3,11 +3,11 @@ package org.hisp.dhis.smscompression;
 import java.io.FileReader;
 
 import org.apache.commons.io.IOUtils;
-import org.hisp.dhis.smscompression.models.AggregateDatasetSMSSubmission;
-import org.hisp.dhis.smscompression.models.EnrollmentSMSSubmission;
-import org.hisp.dhis.smscompression.models.SMSMetadata;
-import org.hisp.dhis.smscompression.models.SMSSubmission;
-import org.hisp.dhis.smscompression.models.SMSSubmissionHeader;
+import org.hisp.dhis.smscompression.models.AggregateDatasetSmsSubmission;
+import org.hisp.dhis.smscompression.models.EnrollmentSmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsMetadata;
+import org.hisp.dhis.smscompression.models.SmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsSubmissionHeader;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -16,13 +16,13 @@ import com.google.gson.Gson;
 public class TestCustomMetadata
 {
 
-    SMSMetadata meta;
+    SmsMetadata meta;
 
-    SMSSubmissionWriter writer;
+    SmsSubmissionWriter writer;
 
-    SMSSubmissionReader reader;
+    SmsSubmissionReader reader;
 
-    public String compressSubm( SMSSubmission subm )
+    public String compressSubm( SmsSubmission subm )
         throws Exception
     {
         byte[] compressSubm = writer.compress( subm );
@@ -31,11 +31,11 @@ public class TestCustomMetadata
         return comp64;
     }
 
-    public SMSSubmission decompressSubm( String comp64 )
+    public SmsSubmission decompressSubm( String comp64 )
         throws Exception
     {
         byte[] decSubmBytes = TestUtils.decBase64( comp64 );
-        SMSSubmissionHeader header = reader.readHeader( decSubmBytes );
+        SmsSubmissionHeader header = reader.readHeader( decSubmBytes );
         Assert.assertNotNull( header );
         return reader.readSubmission( decSubmBytes, meta );
     }
@@ -46,12 +46,12 @@ public class TestCustomMetadata
         try
         {
             meta = null;
-            writer = new SMSSubmissionWriter( meta );
-            reader = new SMSSubmissionReader();
+            writer = new SmsSubmissionWriter( meta );
+            reader = new SmsSubmissionReader();
 
-            AggregateDatasetSMSSubmission origSubm = CreateSubm.createAggregateDatasetSubmission();
+            AggregateDatasetSmsSubmission origSubm = CreateSubm.createAggregateDatasetSubmission();
             String comp64 = compressSubm( origSubm );
-            AggregateDatasetSMSSubmission decSubm = (AggregateDatasetSMSSubmission) decompressSubm( comp64 );
+            AggregateDatasetSmsSubmission decSubm = (AggregateDatasetSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -67,13 +67,13 @@ public class TestCustomMetadata
     {
         try
         {
-            meta = new SMSMetadata();
-            writer = new SMSSubmissionWriter( meta );
-            reader = new SMSSubmissionReader();
+            meta = new SmsMetadata();
+            writer = new SmsSubmissionWriter( meta );
+            reader = new SmsSubmissionReader();
 
-            AggregateDatasetSMSSubmission origSubm = CreateSubm.createAggregateDatasetSubmission();
+            AggregateDatasetSmsSubmission origSubm = CreateSubm.createAggregateDatasetSubmission();
             String comp64 = compressSubm( origSubm );
-            AggregateDatasetSMSSubmission decSubm = (AggregateDatasetSMSSubmission) decompressSubm( comp64 );
+            AggregateDatasetSmsSubmission decSubm = (AggregateDatasetSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -91,14 +91,14 @@ public class TestCustomMetadata
         {
             Gson gson = new Gson();
             String metadataJson = IOUtils.toString( new FileReader( "src/test/resources/metadata.json" ) );
-            meta = gson.fromJson( metadataJson, SMSMetadata.class );
+            meta = gson.fromJson( metadataJson, SmsMetadata.class );
             meta.dataElements = null;
-            writer = new SMSSubmissionWriter( meta );
-            reader = new SMSSubmissionReader();
+            writer = new SmsSubmissionWriter( meta );
+            reader = new SmsSubmissionReader();
 
-            AggregateDatasetSMSSubmission origSubm = CreateSubm.createAggregateDatasetSubmission();
+            AggregateDatasetSmsSubmission origSubm = CreateSubm.createAggregateDatasetSubmission();
             String comp64 = compressSubm( origSubm );
-            AggregateDatasetSMSSubmission decSubm = (AggregateDatasetSMSSubmission) decompressSubm( comp64 );
+            AggregateDatasetSmsSubmission decSubm = (AggregateDatasetSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -116,14 +116,14 @@ public class TestCustomMetadata
         {
             Gson gson = new Gson();
             String metadataJson = IOUtils.toString( new FileReader( "src/test/resources/metadata.json" ) );
-            meta = gson.fromJson( metadataJson, SMSMetadata.class );
+            meta = gson.fromJson( metadataJson, SmsMetadata.class );
             meta.trackedEntityAttributes = null;
-            writer = new SMSSubmissionWriter( meta );
-            reader = new SMSSubmissionReader();
+            writer = new SmsSubmissionWriter( meta );
+            reader = new SmsSubmissionReader();
 
-            EnrollmentSMSSubmission origSubm = CreateSubm.createEnrollmentSubmission();
+            EnrollmentSmsSubmission origSubm = CreateSubm.createEnrollmentSubmission();
             String comp64 = compressSubm( origSubm );
-            EnrollmentSMSSubmission decSubm = (EnrollmentSMSSubmission) decompressSubm( comp64 );
+            EnrollmentSmsSubmission decSubm = (EnrollmentSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -141,14 +141,14 @@ public class TestCustomMetadata
         {
             Gson gson = new Gson();
             String metadataJson = IOUtils.toString( new FileReader( "src/test/resources/metadata.json" ) );
-            meta = gson.fromJson( metadataJson, SMSMetadata.class );
-            writer = new SMSSubmissionWriter( meta );
+            meta = gson.fromJson( metadataJson, SmsMetadata.class );
+            writer = new SmsSubmissionWriter( meta );
             writer.setHashingEnabled( false );
-            reader = new SMSSubmissionReader();
+            reader = new SmsSubmissionReader();
 
-            AggregateDatasetSMSSubmission origSubm = CreateSubm.createAggregateDatasetSubmission();
+            AggregateDatasetSmsSubmission origSubm = CreateSubm.createAggregateDatasetSubmission();
             String comp64 = compressSubm( origSubm );
-            AggregateDatasetSMSSubmission decSubm = (AggregateDatasetSMSSubmission) decompressSubm( comp64 );
+            AggregateDatasetSmsSubmission decSubm = (AggregateDatasetSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }

--- a/src/test/java/org/hisp/dhis/smscompression/TestEmptyVals.java
+++ b/src/test/java/org/hisp/dhis/smscompression/TestEmptyVals.java
@@ -33,14 +33,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
-import org.hisp.dhis.smscompression.models.AggregateDatasetSMSSubmission;
-import org.hisp.dhis.smscompression.models.EnrollmentSMSSubmission;
-import org.hisp.dhis.smscompression.models.SMSEvent;
-import org.hisp.dhis.smscompression.models.SMSMetadata;
-import org.hisp.dhis.smscompression.models.SMSSubmission;
-import org.hisp.dhis.smscompression.models.SMSSubmissionHeader;
-import org.hisp.dhis.smscompression.models.SimpleEventSMSSubmission;
-import org.hisp.dhis.smscompression.models.TrackerEventSMSSubmission;
+import org.hisp.dhis.smscompression.models.AggregateDatasetSmsSubmission;
+import org.hisp.dhis.smscompression.models.EnrollmentSmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsEvent;
+import org.hisp.dhis.smscompression.models.SmsMetadata;
+import org.hisp.dhis.smscompression.models.SmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsSubmissionHeader;
+import org.hisp.dhis.smscompression.models.SimpleEventSmsSubmission;
+import org.hisp.dhis.smscompression.models.TrackerEventSmsSubmission;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -50,13 +50,13 @@ import com.google.gson.Gson;
 
 public class TestEmptyVals
 {
-    SMSMetadata meta;
+    SmsMetadata meta;
 
-    SMSSubmissionWriter writer;
+    SmsSubmissionWriter writer;
 
-    SMSSubmissionReader reader;
+    SmsSubmissionReader reader;
 
-    public String compressSubm( SMSSubmission subm )
+    public String compressSubm( SmsSubmission subm )
         throws Exception
     {
         byte[] compressSubm = writer.compress( subm );
@@ -65,11 +65,11 @@ public class TestEmptyVals
         return comp64;
     }
 
-    public SMSSubmission decompressSubm( String comp64 )
+    public SmsSubmission decompressSubm( String comp64 )
         throws Exception
     {
         byte[] decSubmBytes = TestUtils.decBase64( comp64 );
-        SMSSubmissionHeader header = reader.readHeader( decSubmBytes );
+        SmsSubmissionHeader header = reader.readHeader( decSubmBytes );
         Assert.assertNotNull( header );
         return reader.readSubmission( decSubmBytes, meta );
     }
@@ -80,9 +80,9 @@ public class TestEmptyVals
     {
         Gson gson = new Gson();
         String metadataJson = IOUtils.toString( new FileReader( "src/test/resources/metadata.json" ) );
-        meta = gson.fromJson( metadataJson, SMSMetadata.class );
-        writer = new SMSSubmissionWriter( meta );
-        reader = new SMSSubmissionReader();
+        meta = gson.fromJson( metadataJson, SmsMetadata.class );
+        writer = new SmsSubmissionWriter( meta );
+        reader = new SmsSubmissionReader();
     }
 
     @After
@@ -96,10 +96,10 @@ public class TestEmptyVals
     {
         try
         {
-            AggregateDatasetSMSSubmission origSubm = CreateSubm.createAggregateDatasetSubmission();
+            AggregateDatasetSmsSubmission origSubm = CreateSubm.createAggregateDatasetSubmission();
             origSubm.setValues( null );
             String comp64 = compressSubm( origSubm );
-            AggregateDatasetSMSSubmission decSubm = (AggregateDatasetSMSSubmission) decompressSubm( comp64 );
+            AggregateDatasetSmsSubmission decSubm = (AggregateDatasetSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -115,13 +115,13 @@ public class TestEmptyVals
     {
         try
         {
-            SimpleEventSMSSubmission origSubm = CreateSubm.createSimpleEventSubmission();
+            SimpleEventSmsSubmission origSubm = CreateSubm.createSimpleEventSubmission();
             origSubm.setEventDate( null );
             origSubm.setDueDate( null );
             origSubm.setCoordinates( null );
             origSubm.setValues( null );
             String comp64 = compressSubm( origSubm );
-            SimpleEventSMSSubmission decSubm = (SimpleEventSMSSubmission) decompressSubm( comp64 );
+            SimpleEventSmsSubmission decSubm = (SimpleEventSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -137,14 +137,14 @@ public class TestEmptyVals
     {
         try
         {
-            EnrollmentSMSSubmission origSubm = CreateSubm.createEnrollmentSubmission();
+            EnrollmentSmsSubmission origSubm = CreateSubm.createEnrollmentSubmission();
             origSubm.setEnrollmentDate( null );
             origSubm.setIncidentDate( null );
             origSubm.setCoordinates( null );
             origSubm.setValues( null );
             origSubm.setEvents( null );
             String comp64 = compressSubm( origSubm );
-            EnrollmentSMSSubmission decSubm = (EnrollmentSMSSubmission) decompressSubm( comp64 );
+            EnrollmentSmsSubmission decSubm = (EnrollmentSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -160,9 +160,9 @@ public class TestEmptyVals
     {
         try
         {
-            EnrollmentSMSSubmission origSubm = CreateSubm.createEnrollmentSubmission();
-            List<SMSEvent> blankEvents = new ArrayList<>();
-            for ( SMSEvent e : origSubm.getEvents() )
+            EnrollmentSmsSubmission origSubm = CreateSubm.createEnrollmentSubmission();
+            List<SmsEvent> blankEvents = new ArrayList<>();
+            for ( SmsEvent e : origSubm.getEvents() )
             {
                 e.setEventDate( null );
                 e.setDueDate( null );
@@ -172,7 +172,7 @@ public class TestEmptyVals
             }
             origSubm.setEvents( blankEvents );
             String comp64 = compressSubm( origSubm );
-            EnrollmentSMSSubmission decSubm = (EnrollmentSMSSubmission) decompressSubm( comp64 );
+            EnrollmentSmsSubmission decSubm = (EnrollmentSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -188,13 +188,13 @@ public class TestEmptyVals
     {
         try
         {
-            TrackerEventSMSSubmission origSubm = CreateSubm.createTrackerEventSubmission();
+            TrackerEventSmsSubmission origSubm = CreateSubm.createTrackerEventSubmission();
             origSubm.setEventDate( null );
             origSubm.setDueDate( null );
             origSubm.setCoordinates( null );
             origSubm.setValues( null );
             String comp64 = compressSubm( origSubm );
-            TrackerEventSMSSubmission decSubm = (TrackerEventSMSSubmission) decompressSubm( comp64 );
+            TrackerEventSmsSubmission decSubm = (TrackerEventSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }

--- a/src/test/java/org/hisp/dhis/smscompression/TestEncodeDecode.java
+++ b/src/test/java/org/hisp/dhis/smscompression/TestEncodeDecode.java
@@ -33,15 +33,15 @@ import static org.junit.Assert.assertEquals;
 import java.io.FileReader;
 
 import org.apache.commons.io.IOUtils;
-import org.hisp.dhis.smscompression.models.AggregateDatasetSMSSubmission;
-import org.hisp.dhis.smscompression.models.DeleteSMSSubmission;
-import org.hisp.dhis.smscompression.models.EnrollmentSMSSubmission;
-import org.hisp.dhis.smscompression.models.RelationshipSMSSubmission;
-import org.hisp.dhis.smscompression.models.SMSMetadata;
-import org.hisp.dhis.smscompression.models.SMSSubmission;
-import org.hisp.dhis.smscompression.models.SMSSubmissionHeader;
-import org.hisp.dhis.smscompression.models.SimpleEventSMSSubmission;
-import org.hisp.dhis.smscompression.models.TrackerEventSMSSubmission;
+import org.hisp.dhis.smscompression.models.AggregateDatasetSmsSubmission;
+import org.hisp.dhis.smscompression.models.DeleteSmsSubmission;
+import org.hisp.dhis.smscompression.models.EnrollmentSmsSubmission;
+import org.hisp.dhis.smscompression.models.RelationshipSmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsMetadata;
+import org.hisp.dhis.smscompression.models.SmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsSubmissionHeader;
+import org.hisp.dhis.smscompression.models.SimpleEventSmsSubmission;
+import org.hisp.dhis.smscompression.models.TrackerEventSmsSubmission;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -51,13 +51,13 @@ import com.google.gson.Gson;
 
 public class TestEncodeDecode
 {
-    SMSMetadata meta;
+    SmsMetadata meta;
 
-    SMSSubmissionWriter writer;
+    SmsSubmissionWriter writer;
 
-    SMSSubmissionReader reader;
+    SmsSubmissionReader reader;
 
-    public String compressSubm( SMSSubmission subm )
+    public String compressSubm( SmsSubmission subm )
         throws Exception
     {
         byte[] compressSubm = writer.compress( subm );
@@ -66,11 +66,11 @@ public class TestEncodeDecode
         return comp64;
     }
 
-    public SMSSubmission decompressSubm( String comp64 )
+    public SmsSubmission decompressSubm( String comp64 )
         throws Exception
     {
         byte[] decSubmBytes = TestUtils.decBase64( comp64 );
-        SMSSubmissionHeader header = reader.readHeader( decSubmBytes );
+        SmsSubmissionHeader header = reader.readHeader( decSubmBytes );
         Assert.assertNotNull( header );
         return reader.readSubmission( decSubmBytes, meta );
     }
@@ -81,9 +81,9 @@ public class TestEncodeDecode
     {
         Gson gson = new Gson();
         String metadataJson = IOUtils.toString( new FileReader( "src/test/resources/metadata.json" ) );
-        meta = gson.fromJson( metadataJson, SMSMetadata.class );
-        writer = new SMSSubmissionWriter( meta );
-        reader = new SMSSubmissionReader();
+        meta = gson.fromJson( metadataJson, SmsMetadata.class );
+        writer = new SmsSubmissionWriter( meta );
+        reader = new SmsSubmissionReader();
     }
 
     @After
@@ -97,9 +97,9 @@ public class TestEncodeDecode
     {
         try
         {
-            RelationshipSMSSubmission origSubm = CreateSubm.createRelationshipSubmission();
+            RelationshipSmsSubmission origSubm = CreateSubm.createRelationshipSubmission();
             String comp64 = compressSubm( origSubm );
-            RelationshipSMSSubmission decSubm = (RelationshipSMSSubmission) decompressSubm( comp64 );
+            RelationshipSmsSubmission decSubm = (RelationshipSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -115,9 +115,9 @@ public class TestEncodeDecode
     {
         try
         {
-            DeleteSMSSubmission origSubm = CreateSubm.createDeleteSubmission();
+            DeleteSmsSubmission origSubm = CreateSubm.createDeleteSubmission();
             String comp64 = compressSubm( origSubm );
-            DeleteSMSSubmission decSubm = (DeleteSMSSubmission) decompressSubm( comp64 );
+            DeleteSmsSubmission decSubm = (DeleteSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -133,9 +133,9 @@ public class TestEncodeDecode
     {
         try
         {
-            SimpleEventSMSSubmission origSubm = CreateSubm.createSimpleEventSubmission();
+            SimpleEventSmsSubmission origSubm = CreateSubm.createSimpleEventSubmission();
             String comp64 = compressSubm( origSubm );
-            SimpleEventSMSSubmission decSubm = (SimpleEventSMSSubmission) decompressSubm( comp64 );
+            SimpleEventSmsSubmission decSubm = (SimpleEventSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -151,9 +151,9 @@ public class TestEncodeDecode
     {
         try
         {
-            AggregateDatasetSMSSubmission origSubm = CreateSubm.createAggregateDatasetSubmission();
+            AggregateDatasetSmsSubmission origSubm = CreateSubm.createAggregateDatasetSubmission();
             String comp64 = compressSubm( origSubm );
-            AggregateDatasetSMSSubmission decSubm = (AggregateDatasetSMSSubmission) decompressSubm( comp64 );
+            AggregateDatasetSmsSubmission decSubm = (AggregateDatasetSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -169,9 +169,9 @@ public class TestEncodeDecode
     {
         try
         {
-            EnrollmentSMSSubmission origSubm = CreateSubm.createEnrollmentSubmission();
+            EnrollmentSmsSubmission origSubm = CreateSubm.createEnrollmentSubmission();
             String comp64 = compressSubm( origSubm );
-            EnrollmentSMSSubmission decSubm = (EnrollmentSMSSubmission) decompressSubm( comp64 );
+            EnrollmentSmsSubmission decSubm = (EnrollmentSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -187,9 +187,9 @@ public class TestEncodeDecode
     {
         try
         {
-            TrackerEventSMSSubmission origSubm = CreateSubm.createTrackerEventSubmission();
+            TrackerEventSmsSubmission origSubm = CreateSubm.createTrackerEventSubmission();
             String comp64 = compressSubm( origSubm );
-            TrackerEventSMSSubmission decSubm = (TrackerEventSMSSubmission) decompressSubm( comp64 );
+            TrackerEventSmsSubmission decSubm = (TrackerEventSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -205,7 +205,7 @@ public class TestEncodeDecode
     {
         try
         {
-            TrackerEventSMSSubmission origSubm = CreateSubm.createTrackerEventSubmission();
+            TrackerEventSmsSubmission origSubm = CreateSubm.createTrackerEventSubmission();
             String comp64 = compressSubm( origSubm );
             comp64 = comp64.subSequence( 0, comp64.length() - 4 ).toString();
             comp64 = TestUtils.stripTillValid( comp64 );
@@ -213,7 +213,7 @@ public class TestEncodeDecode
         }
         catch ( Exception e )
         {
-            assertEquals( e.getClass(), SMSCompressionException.class );
+            assertEquals( e.getClass(), SmsCompressionException.class );
             assertEquals( e.getMessage(), "Invalid CRC - CRC in header does not match submission" );
             return;
         }
@@ -226,7 +226,7 @@ public class TestEncodeDecode
     {
         try
         {
-            TrackerEventSMSSubmission origSubm = CreateSubm.createTrackerEventSubmission();
+            TrackerEventSmsSubmission origSubm = CreateSubm.createTrackerEventSubmission();
             String comp64 = compressSubm( origSubm );
             comp64 = comp64.subSequence( 1, comp64.length() ).toString();
             comp64 = TestUtils.stripTillValid( comp64 );
@@ -234,7 +234,7 @@ public class TestEncodeDecode
         }
         catch ( Exception e )
         {
-            assertEquals( SMSCompressionException.class, e.getClass() );
+            assertEquals( SmsCompressionException.class, e.getClass() );
             assertEquals( "Invalid CRC - CRC in header does not match submission", e.getMessage() );
             return;
         }

--- a/src/test/java/org/hisp/dhis/smscompression/TestErrors.java
+++ b/src/test/java/org/hisp/dhis/smscompression/TestErrors.java
@@ -2,8 +2,8 @@ package org.hisp.dhis.smscompression;
 
 import java.util.ArrayList;
 
-import org.hisp.dhis.smscompression.SMSConsts.MetadataType;
-import org.hisp.dhis.smscompression.models.UID;
+import org.hisp.dhis.smscompression.SmsConsts.MetadataType;
+import org.hisp.dhis.smscompression.models.Uid;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -11,24 +11,24 @@ public class TestErrors
 {
 
     @Test
-    public void testPrintSMSResponse()
+    public void testPrintSmsResponse()
     {
-        UID ouid = new UID( "ooooooooooo", MetadataType.ORGANISATION_UNIT );
-        UID programid = new UID( "ppppppppppp", MetadataType.PROGRAM );
-        String errorMsg = SMSResponse.OU_NOTIN_PROGRAM.set( ouid, programid ).toString();
+        Uid ouid = new Uid( "ooooooooooo", MetadataType.ORGANISATION_UNIT );
+        Uid programid = new Uid( "ppppppppppp", MetadataType.PROGRAM );
+        String errorMsg = SmsResponse.OU_NOTIN_PROGRAM.set( ouid, programid ).toString();
         String expectedMsg = "302:ooooooooooo,ppppppppppp:Organisation unit [ooooooooooo] is not assigned to program [ppppppppppp]";
         Assert.assertEquals( expectedMsg, errorMsg );
     }
 
     @Test
-    public void testPrintSMSResponseList()
+    public void testPrintSmsResponseList()
     {
-        UID ouid = new UID( "ooooooooooo", MetadataType.ORGANISATION_UNIT );
-        UID programid = new UID( "ppppppppppp", MetadataType.PROGRAM );
+        Uid ouid = new Uid( "ooooooooooo", MetadataType.ORGANISATION_UNIT );
+        Uid programid = new Uid( "ppppppppppp", MetadataType.PROGRAM );
         ArrayList<Object> uidList = new ArrayList<>();
         uidList.add( ouid );
         uidList.add( programid );
-        String errorMsg = SMSResponse.OU_NOTIN_PROGRAM.setList( uidList ).toString();
+        String errorMsg = SmsResponse.OU_NOTIN_PROGRAM.setList( uidList ).toString();
         String expectedMsg = "302:ooooooooooo,ppppppppppp:Organisation unit [ooooooooooo] is not assigned to program [ppppppppppp]";
         Assert.assertEquals( expectedMsg, errorMsg );
     }

--- a/src/test/java/org/hisp/dhis/smscompression/TestUtils.java
+++ b/src/test/java/org/hisp/dhis/smscompression/TestUtils.java
@@ -34,11 +34,11 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
-import org.hisp.dhis.smscompression.SMSConsts.SMSEventStatus;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEventStatus;
 import org.hisp.dhis.smscompression.models.GeoPoint;
-import org.hisp.dhis.smscompression.models.SMSDataValue;
-import org.hisp.dhis.smscompression.models.SMSEvent;
-import org.hisp.dhis.smscompression.models.SMSSubmission;
+import org.hisp.dhis.smscompression.models.SmsDataValue;
+import org.hisp.dhis.smscompression.models.SmsEvent;
+import org.hisp.dhis.smscompression.models.SmsSubmission;
 import org.junit.Assert;
 
 import com.google.gson.Gson;
@@ -54,23 +54,23 @@ public class TestUtils
         return cal.getTime();
     }
 
-    public static List<SMSEvent> createEventList()
+    public static List<SmsEvent> createEventList()
     {
-        List<SMSEvent> events = new ArrayList<>();
+        List<SmsEvent> events = new ArrayList<>();
         for ( int i = 1; i <= 3; i++ )
         {
-            SMSEvent event = new SMSEvent();
+            SmsEvent event = new SmsEvent();
             event.setOrgUnit( "DiszpKrYNg8" ); // Ngelehun CHC
             event.setProgramStage( "A03MvHHogjR" ); // Birth
-            event.setEventStatus( SMSEventStatus.COMPLETED );
+            event.setEventStatus( SmsEventStatus.COMPLETED );
             event.setAttributeOptionCombo( "HllvX50cXC0" ); // Default
                                                             // catOptionCombo
             event.setEvent( "r7M1gUFK3X" + i ); // New UID
             event.setEventDate( getNowWithoutMillis() );
             event.setDueDate( getNowWithoutMillis() );
             event.setCoordinates( new GeoPoint( 8.4844694f, -13.2364332f ) );
-            ArrayList<SMSDataValue> values = new ArrayList<>();
-            values.add( new SMSDataValue( "HllvX50cXC0", "UXz7xuGCEhU", String.valueOf( i + 1 ) ) ); // Weight
+            ArrayList<SmsDataValue> values = new ArrayList<>();
+            values.add( new SmsDataValue( "HllvX50cXC0", "UXz7xuGCEhU", String.valueOf( i + 1 ) ) ); // Weight
             event.setValues( values );
             events.add( event );
         }
@@ -78,7 +78,7 @@ public class TestUtils
         return events;
     }
 
-    public static void printSubm( SMSSubmission subm )
+    public static void printSubm( SmsSubmission subm )
     {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         System.out.println( gson.toJson( subm ) );
@@ -120,7 +120,7 @@ public class TestUtils
         System.out.println( "************************" );
     }
 
-    public static void checkSubmissionsAreEqual( SMSSubmission origSubm, SMSSubmission decSubm )
+    public static void checkSubmissionsAreEqual( SmsSubmission origSubm, SmsSubmission decSubm )
     {
         if ( !origSubm.equals( decSubm ) )
         {

--- a/src/test/java/org/hisp/dhis/smscompression/TestVersions.java
+++ b/src/test/java/org/hisp/dhis/smscompression/TestVersions.java
@@ -33,15 +33,15 @@ import static org.junit.Assert.assertEquals;
 import java.io.FileReader;
 
 import org.apache.commons.io.IOUtils;
-import org.hisp.dhis.smscompression.models.AggregateDatasetSMSSubmission;
-import org.hisp.dhis.smscompression.models.DeleteSMSSubmission;
-import org.hisp.dhis.smscompression.models.EnrollmentSMSSubmission;
-import org.hisp.dhis.smscompression.models.RelationshipSMSSubmission;
-import org.hisp.dhis.smscompression.models.SMSMetadata;
-import org.hisp.dhis.smscompression.models.SMSSubmission;
-import org.hisp.dhis.smscompression.models.SMSSubmissionHeader;
-import org.hisp.dhis.smscompression.models.SimpleEventSMSSubmission;
-import org.hisp.dhis.smscompression.models.TrackerEventSMSSubmission;
+import org.hisp.dhis.smscompression.models.AggregateDatasetSmsSubmission;
+import org.hisp.dhis.smscompression.models.DeleteSmsSubmission;
+import org.hisp.dhis.smscompression.models.EnrollmentSmsSubmission;
+import org.hisp.dhis.smscompression.models.RelationshipSmsSubmission;
+import org.hisp.dhis.smscompression.models.SimpleEventSmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsMetadata;
+import org.hisp.dhis.smscompression.models.SmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsSubmissionHeader;
+import org.hisp.dhis.smscompression.models.TrackerEventSmsSubmission;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -51,13 +51,13 @@ import com.google.gson.Gson;
 
 public class TestVersions
 {
-    SMSMetadata meta;
+    SmsMetadata meta;
 
-    SMSSubmissionWriter writer;
+    SmsSubmissionWriter writer;
 
-    SMSSubmissionReader reader;
+    SmsSubmissionReader reader;
 
-    public String compressSubm( SMSSubmission subm, int version )
+    public String compressSubm( SmsSubmission subm, int version )
         throws Exception
     {
         byte[] compressSubm = writer.compress( subm, version );
@@ -66,11 +66,11 @@ public class TestVersions
         return comp64;
     }
 
-    public SMSSubmission decompressSubm( String comp64 )
+    public SmsSubmission decompressSubm( String comp64 )
         throws Exception
     {
         byte[] decSubmBytes = TestUtils.decBase64( comp64 );
-        SMSSubmissionHeader header = reader.readHeader( decSubmBytes );
+        SmsSubmissionHeader header = reader.readHeader( decSubmBytes );
         Assert.assertNotNull( header );
         return reader.readSubmission( decSubmBytes, meta );
     }
@@ -81,9 +81,9 @@ public class TestVersions
     {
         Gson gson = new Gson();
         String metadataJson = IOUtils.toString( new FileReader( "src/test/resources/metadata.json" ) );
-        meta = gson.fromJson( metadataJson, SMSMetadata.class );
-        writer = new SMSSubmissionWriter( meta );
-        reader = new SMSSubmissionReader();
+        meta = gson.fromJson( metadataJson, SmsMetadata.class );
+        writer = new SmsSubmissionWriter( meta );
+        reader = new SmsSubmissionReader();
     }
 
     @After
@@ -97,9 +97,9 @@ public class TestVersions
     {
         try
         {
-            SimpleEventSMSSubmission origSubm = CreateSubmV1.createSimpleEventSubmissionV1();
+            SimpleEventSmsSubmission origSubm = CreateSubmV1.createSimpleEventSubmissionV1();
             String comp64 = compressSubm( origSubm, 1 );
-            SimpleEventSMSSubmission decSubm = (SimpleEventSMSSubmission) decompressSubm( comp64 );
+            SimpleEventSmsSubmission decSubm = (SimpleEventSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -115,9 +115,9 @@ public class TestVersions
     {
         try
         {
-            AggregateDatasetSMSSubmission origSubm = CreateSubm.createAggregateDatasetSubmission();
+            AggregateDatasetSmsSubmission origSubm = CreateSubm.createAggregateDatasetSubmission();
             String comp64 = compressSubm( origSubm, 1 );
-            AggregateDatasetSMSSubmission decSubm = (AggregateDatasetSMSSubmission) decompressSubm( comp64 );
+            AggregateDatasetSmsSubmission decSubm = (AggregateDatasetSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -133,9 +133,9 @@ public class TestVersions
     {
         try
         {
-            EnrollmentSMSSubmission origSubm = CreateSubmV1.createEnrollmentSubmissionV1();
+            EnrollmentSmsSubmission origSubm = CreateSubmV1.createEnrollmentSubmissionV1();
             String comp64 = compressSubm( origSubm, 1 );
-            EnrollmentSMSSubmission decSubm = (EnrollmentSMSSubmission) decompressSubm( comp64 );
+            EnrollmentSmsSubmission decSubm = (EnrollmentSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -151,9 +151,9 @@ public class TestVersions
     {
         try
         {
-            TrackerEventSMSSubmission origSubm = CreateSubmV1.createTrackerEventSubmissionV1();
+            TrackerEventSmsSubmission origSubm = CreateSubmV1.createTrackerEventSubmissionV1();
             String comp64 = compressSubm( origSubm, 1 );
-            TrackerEventSMSSubmission decSubm = (TrackerEventSMSSubmission) decompressSubm( comp64 );
+            TrackerEventSmsSubmission decSubm = (TrackerEventSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -169,9 +169,9 @@ public class TestVersions
     {
         try
         {
-            DeleteSMSSubmission origSubm = CreateSubm.createDeleteSubmission();
+            DeleteSmsSubmission origSubm = CreateSubm.createDeleteSubmission();
             String comp64 = compressSubm( origSubm, 1 );
-            DeleteSMSSubmission decSubm = (DeleteSMSSubmission) decompressSubm( comp64 );
+            DeleteSmsSubmission decSubm = (DeleteSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -187,9 +187,9 @@ public class TestVersions
     {
         try
         {
-            RelationshipSMSSubmission origSubm = CreateSubm.createRelationshipSubmission();
+            RelationshipSmsSubmission origSubm = CreateSubm.createRelationshipSubmission();
             String comp64 = compressSubm( origSubm, 1 );
-            RelationshipSMSSubmission decSubm = (RelationshipSMSSubmission) decompressSubm( comp64 );
+            RelationshipSmsSubmission decSubm = (RelationshipSmsSubmission) decompressSubm( comp64 );
 
             TestUtils.checkSubmissionsAreEqual( origSubm, decSubm );
         }
@@ -209,8 +209,8 @@ public class TestVersions
         }
         catch ( Exception e )
         {
-            assertEquals( e.getClass(), SMSCompressionException.class );
-            assertEquals( e.getMessage(), "Version 0 of TrackerEventSMSSubmission is not supported" );
+            assertEquals( e.getClass(), SmsCompressionException.class );
+            assertEquals( e.getMessage(), "Version 0 of TrackerEventSmsSubmission is not supported" );
             return;
         }
 
@@ -220,7 +220,7 @@ public class TestVersions
     @Test
     public void testWriteFutureVersion()
     {
-        SMSSubmission subm = CreateSubm.createTrackerEventSubmission();
+        SmsSubmission subm = CreateSubm.createTrackerEventSubmission();
         int futureVer = subm.getCurrentVersion() + 1;
 
         try
@@ -229,9 +229,9 @@ public class TestVersions
         }
         catch ( Exception e )
         {
-            assertEquals( e.getClass(), SMSCompressionException.class );
+            assertEquals( e.getClass(), SmsCompressionException.class );
             assertEquals( e.getMessage(),
-                String.format( "Version %d of TrackerEventSMSSubmission is not supported", futureVer ) );
+                String.format( "Version %d of TrackerEventSmsSubmission is not supported", futureVer ) );
             return;
         }
 
@@ -247,8 +247,8 @@ public class TestVersions
         }
         catch ( Exception e )
         {
-            assertEquals( e.getClass(), SMSCompressionException.class );
-            assertEquals( e.getMessage(), "Version 0 of RelationshipSMSSubmission is not supported" );
+            assertEquals( e.getClass(), SmsCompressionException.class );
+            assertEquals( e.getMessage(), "Version 0 of RelationshipSmsSubmission is not supported" );
             return;
         }
 
@@ -258,7 +258,7 @@ public class TestVersions
     @Test
     public void testWriteFutureVersionRelationship()
     {
-        SMSSubmission subm = CreateSubm.createRelationshipSubmission();
+        SmsSubmission subm = CreateSubm.createRelationshipSubmission();
         int futureVer = subm.getCurrentVersion() + 1;
 
         try
@@ -267,9 +267,9 @@ public class TestVersions
         }
         catch ( Exception e )
         {
-            assertEquals( e.getClass(), SMSCompressionException.class );
+            assertEquals( e.getClass(), SmsCompressionException.class );
             assertEquals( e.getMessage(),
-                String.format( "Version %d of RelationshipSMSSubmission is not supported", futureVer ) );
+                String.format( "Version %d of RelationshipSmsSubmission is not supported", futureVer ) );
             return;
         }
 


### PR DESCRIPTION
I realise this PR probably looks huge, but **there is no functional change**. This is purely about renaming classes, methods, variables to align with making acronyms part of camel case all throughout this library.

i.e. SMS -> Sms, UID -> Uid